### PR TITLE
Item UI positioning fix

### DIFF
--- a/Assets/Characters/UI.prefab
+++ b/Assets/Characters/UI.prefab
@@ -169,9 +169,9 @@ RectTransform:
   - {fileID: 4255705865552741630}
   m_Father: {fileID: 701913431931177208}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
-  m_AnchorMin: {x: 0.5, y: 0.5}
-  m_AnchorMax: {x: 0.5, y: 0.5}
-  m_AnchoredPosition: {x: -863.433, y: 388.43298}
+  m_AnchorMin: {x: 0, y: 1}
+  m_AnchorMax: {x: 0, y: 1}
+  m_AnchoredPosition: {x: 96.56702, y: -96.56702}
   m_SizeDelta: {x: 193.13452, y: 193.13452}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!1 &633436605127484506


### PR DESCRIPTION
When playing with two players on a screen with a 16:10 aspect ratio, there was an issue where the left player's item UI would be cut-off off of the screen and the right player's UI would overlap onto the left player's screen.

This PR fixes this by anchoring the item UI to the top left corner of the screen instead of the center of the screen (as it previously was anchored to).