### PR TITLE
Fix for camera clipping into players while ragdoll is enabled

### DIFF
--- a/Assets/Characters/Players/Bestudo.prefab
+++ b/Assets/Characters/Players/Bestudo.prefab
@@ -9,7 +9,7 @@ GameObject:
   serializedVersion: 6
   m_Component:
   - component: {fileID: 2763277223713773619}
-  m_Layer: 0
+  m_Layer: 10
   m_Name: ItemDropPoint
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -39,10 +39,175 @@ PrefabInstance:
     serializedVersion: 3
     m_TransformParent: {fileID: 8700231470750234645}
     m_Modifications:
+    - target: {fileID: 79994751677477566, guid: b4ec85ebe552cce43b9f60ba08bb9986,
+        type: 3}
+      propertyPath: m_Layer
+      value: 10
+      objectReference: {fileID: 0}
+    - target: {fileID: 124410305922859692, guid: b4ec85ebe552cce43b9f60ba08bb9986,
+        type: 3}
+      propertyPath: m_Layer
+      value: 10
+      objectReference: {fileID: 0}
+    - target: {fileID: 148410831318142720, guid: b4ec85ebe552cce43b9f60ba08bb9986,
+        type: 3}
+      propertyPath: m_Layer
+      value: 10
+      objectReference: {fileID: 0}
+    - target: {fileID: 213999359450992808, guid: b4ec85ebe552cce43b9f60ba08bb9986,
+        type: 3}
+      propertyPath: m_Layer
+      value: 10
+      objectReference: {fileID: 0}
+    - target: {fileID: 303385242730091184, guid: b4ec85ebe552cce43b9f60ba08bb9986,
+        type: 3}
+      propertyPath: m_Layer
+      value: 10
+      objectReference: {fileID: 0}
+    - target: {fileID: 362252788197468770, guid: b4ec85ebe552cce43b9f60ba08bb9986,
+        type: 3}
+      propertyPath: m_Layer
+      value: 10
+      objectReference: {fileID: 0}
+    - target: {fileID: 461015513405860043, guid: b4ec85ebe552cce43b9f60ba08bb9986,
+        type: 3}
+      propertyPath: m_Layer
+      value: 10
+      objectReference: {fileID: 0}
+    - target: {fileID: 667108809009578997, guid: b4ec85ebe552cce43b9f60ba08bb9986,
+        type: 3}
+      propertyPath: m_Layer
+      value: 10
+      objectReference: {fileID: 0}
+    - target: {fileID: 892588368888472289, guid: b4ec85ebe552cce43b9f60ba08bb9986,
+        type: 3}
+      propertyPath: m_Layer
+      value: 10
+      objectReference: {fileID: 0}
+    - target: {fileID: 942396517876991013, guid: b4ec85ebe552cce43b9f60ba08bb9986,
+        type: 3}
+      propertyPath: m_Layer
+      value: 10
+      objectReference: {fileID: 0}
+    - target: {fileID: 1156353553383043778, guid: b4ec85ebe552cce43b9f60ba08bb9986,
+        type: 3}
+      propertyPath: m_Layer
+      value: 10
+      objectReference: {fileID: 0}
+    - target: {fileID: 1271217124482922686, guid: b4ec85ebe552cce43b9f60ba08bb9986,
+        type: 3}
+      propertyPath: m_Layer
+      value: 10
+      objectReference: {fileID: 0}
+    - target: {fileID: 1297242626676435566, guid: b4ec85ebe552cce43b9f60ba08bb9986,
+        type: 3}
+      propertyPath: m_Layer
+      value: 10
+      objectReference: {fileID: 0}
+    - target: {fileID: 1487109047022273789, guid: b4ec85ebe552cce43b9f60ba08bb9986,
+        type: 3}
+      propertyPath: m_Layer
+      value: 10
+      objectReference: {fileID: 0}
+    - target: {fileID: 1590245638783752645, guid: b4ec85ebe552cce43b9f60ba08bb9986,
+        type: 3}
+      propertyPath: m_Layer
+      value: 10
+      objectReference: {fileID: 0}
+    - target: {fileID: 1675124150039465343, guid: b4ec85ebe552cce43b9f60ba08bb9986,
+        type: 3}
+      propertyPath: m_Layer
+      value: 10
+      objectReference: {fileID: 0}
+    - target: {fileID: 1691251559509666630, guid: b4ec85ebe552cce43b9f60ba08bb9986,
+        type: 3}
+      propertyPath: m_Layer
+      value: 10
+      objectReference: {fileID: 0}
+    - target: {fileID: 1954539210245309129, guid: b4ec85ebe552cce43b9f60ba08bb9986,
+        type: 3}
+      propertyPath: m_Layer
+      value: 10
+      objectReference: {fileID: 0}
+    - target: {fileID: 2288234766812106706, guid: b4ec85ebe552cce43b9f60ba08bb9986,
+        type: 3}
+      propertyPath: m_Layer
+      value: 10
+      objectReference: {fileID: 0}
+    - target: {fileID: 2384265134241469911, guid: b4ec85ebe552cce43b9f60ba08bb9986,
+        type: 3}
+      propertyPath: m_Layer
+      value: 10
+      objectReference: {fileID: 0}
+    - target: {fileID: 2631911643725314460, guid: b4ec85ebe552cce43b9f60ba08bb9986,
+        type: 3}
+      propertyPath: m_Layer
+      value: 10
+      objectReference: {fileID: 0}
+    - target: {fileID: 2731668277248155843, guid: b4ec85ebe552cce43b9f60ba08bb9986,
+        type: 3}
+      propertyPath: m_Layer
+      value: 10
+      objectReference: {fileID: 0}
+    - target: {fileID: 2815176810296130471, guid: b4ec85ebe552cce43b9f60ba08bb9986,
+        type: 3}
+      propertyPath: m_Layer
+      value: 10
+      objectReference: {fileID: 0}
+    - target: {fileID: 2993885767314483721, guid: b4ec85ebe552cce43b9f60ba08bb9986,
+        type: 3}
+      propertyPath: m_Layer
+      value: 10
+      objectReference: {fileID: 0}
     - target: {fileID: 3021967919311688469, guid: b4ec85ebe552cce43b9f60ba08bb9986,
         type: 3}
       propertyPath: m_IsActive
       value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3158167450346183422, guid: b4ec85ebe552cce43b9f60ba08bb9986,
+        type: 3}
+      propertyPath: m_Layer
+      value: 10
+      objectReference: {fileID: 0}
+    - target: {fileID: 3261519731185054589, guid: b4ec85ebe552cce43b9f60ba08bb9986,
+        type: 3}
+      propertyPath: m_Layer
+      value: 10
+      objectReference: {fileID: 0}
+    - target: {fileID: 3382791477153405981, guid: b4ec85ebe552cce43b9f60ba08bb9986,
+        type: 3}
+      propertyPath: m_Layer
+      value: 10
+      objectReference: {fileID: 0}
+    - target: {fileID: 3473496490106504461, guid: b4ec85ebe552cce43b9f60ba08bb9986,
+        type: 3}
+      propertyPath: m_Layer
+      value: 10
+      objectReference: {fileID: 0}
+    - target: {fileID: 3965551386561752961, guid: b4ec85ebe552cce43b9f60ba08bb9986,
+        type: 3}
+      propertyPath: m_Layer
+      value: 10
+      objectReference: {fileID: 0}
+    - target: {fileID: 4049235226080989474, guid: b4ec85ebe552cce43b9f60ba08bb9986,
+        type: 3}
+      propertyPath: m_Layer
+      value: 10
+      objectReference: {fileID: 0}
+    - target: {fileID: 4123019166736572854, guid: b4ec85ebe552cce43b9f60ba08bb9986,
+        type: 3}
+      propertyPath: m_Layer
+      value: 10
+      objectReference: {fileID: 0}
+    - target: {fileID: 4379962714969515280, guid: b4ec85ebe552cce43b9f60ba08bb9986,
+        type: 3}
+      propertyPath: m_Layer
+      value: 10
+      objectReference: {fileID: 0}
+    - target: {fileID: 4573845225702683594, guid: b4ec85ebe552cce43b9f60ba08bb9986,
+        type: 3}
+      propertyPath: m_Layer
+      value: 10
       objectReference: {fileID: 0}
     - target: {fileID: 4598510944576842962, guid: b4ec85ebe552cce43b9f60ba08bb9986,
         type: 3}
@@ -83,6 +248,101 @@ PrefabInstance:
         type: 3}
       propertyPath: m_LocalEulerAnglesHint.z
       value: 0.006
+      objectReference: {fileID: 0}
+    - target: {fileID: 4615837805754991937, guid: b4ec85ebe552cce43b9f60ba08bb9986,
+        type: 3}
+      propertyPath: m_Layer
+      value: 10
+      objectReference: {fileID: 0}
+    - target: {fileID: 4618839301074285235, guid: b4ec85ebe552cce43b9f60ba08bb9986,
+        type: 3}
+      propertyPath: m_Layer
+      value: 10
+      objectReference: {fileID: 0}
+    - target: {fileID: 4729235357679740933, guid: b4ec85ebe552cce43b9f60ba08bb9986,
+        type: 3}
+      propertyPath: m_Layer
+      value: 10
+      objectReference: {fileID: 0}
+    - target: {fileID: 4744065846517747052, guid: b4ec85ebe552cce43b9f60ba08bb9986,
+        type: 3}
+      propertyPath: m_Layer
+      value: 10
+      objectReference: {fileID: 0}
+    - target: {fileID: 4785725063470920325, guid: b4ec85ebe552cce43b9f60ba08bb9986,
+        type: 3}
+      propertyPath: m_Layer
+      value: 10
+      objectReference: {fileID: 0}
+    - target: {fileID: 4839400376027762072, guid: b4ec85ebe552cce43b9f60ba08bb9986,
+        type: 3}
+      propertyPath: m_Layer
+      value: 10
+      objectReference: {fileID: 0}
+    - target: {fileID: 4964671586216551111, guid: b4ec85ebe552cce43b9f60ba08bb9986,
+        type: 3}
+      propertyPath: m_Layer
+      value: 10
+      objectReference: {fileID: 0}
+    - target: {fileID: 5287928883399001575, guid: b4ec85ebe552cce43b9f60ba08bb9986,
+        type: 3}
+      propertyPath: m_Layer
+      value: 10
+      objectReference: {fileID: 0}
+    - target: {fileID: 5309959933227355327, guid: b4ec85ebe552cce43b9f60ba08bb9986,
+        type: 3}
+      propertyPath: m_Layer
+      value: 10
+      objectReference: {fileID: 0}
+    - target: {fileID: 5347668616685534540, guid: b4ec85ebe552cce43b9f60ba08bb9986,
+        type: 3}
+      propertyPath: m_Layer
+      value: 10
+      objectReference: {fileID: 0}
+    - target: {fileID: 5487557954401733289, guid: b4ec85ebe552cce43b9f60ba08bb9986,
+        type: 3}
+      propertyPath: m_Layer
+      value: 10
+      objectReference: {fileID: 0}
+    - target: {fileID: 5605750500599973196, guid: b4ec85ebe552cce43b9f60ba08bb9986,
+        type: 3}
+      propertyPath: m_Layer
+      value: 10
+      objectReference: {fileID: 0}
+    - target: {fileID: 5641134919704252824, guid: b4ec85ebe552cce43b9f60ba08bb9986,
+        type: 3}
+      propertyPath: m_Layer
+      value: 10
+      objectReference: {fileID: 0}
+    - target: {fileID: 5763737252058819136, guid: b4ec85ebe552cce43b9f60ba08bb9986,
+        type: 3}
+      propertyPath: m_Layer
+      value: 10
+      objectReference: {fileID: 0}
+    - target: {fileID: 5809251631492105704, guid: b4ec85ebe552cce43b9f60ba08bb9986,
+        type: 3}
+      propertyPath: m_Layer
+      value: 10
+      objectReference: {fileID: 0}
+    - target: {fileID: 5822277988751748363, guid: b4ec85ebe552cce43b9f60ba08bb9986,
+        type: 3}
+      propertyPath: m_Layer
+      value: 10
+      objectReference: {fileID: 0}
+    - target: {fileID: 6000114339932580464, guid: b4ec85ebe552cce43b9f60ba08bb9986,
+        type: 3}
+      propertyPath: m_Layer
+      value: 10
+      objectReference: {fileID: 0}
+    - target: {fileID: 6066920487763201677, guid: b4ec85ebe552cce43b9f60ba08bb9986,
+        type: 3}
+      propertyPath: m_Layer
+      value: 10
+      objectReference: {fileID: 0}
+    - target: {fileID: 6157256424048236700, guid: b4ec85ebe552cce43b9f60ba08bb9986,
+        type: 3}
+      propertyPath: m_Layer
+      value: 10
       objectReference: {fileID: 0}
     - target: {fileID: 6333021178869216943, guid: b4ec85ebe552cce43b9f60ba08bb9986,
         type: 3}
@@ -134,15 +394,95 @@ PrefabInstance:
       propertyPath: m_LocalEulerAnglesHint.z
       value: -0.092
       objectReference: {fileID: 0}
+    - target: {fileID: 6338768921218741740, guid: b4ec85ebe552cce43b9f60ba08bb9986,
+        type: 3}
+      propertyPath: m_Layer
+      value: 10
+      objectReference: {fileID: 0}
+    - target: {fileID: 6375578443610355016, guid: b4ec85ebe552cce43b9f60ba08bb9986,
+        type: 3}
+      propertyPath: m_Layer
+      value: 10
+      objectReference: {fileID: 0}
+    - target: {fileID: 6377711061843519446, guid: b4ec85ebe552cce43b9f60ba08bb9986,
+        type: 3}
+      propertyPath: m_Layer
+      value: 10
+      objectReference: {fileID: 0}
+    - target: {fileID: 6601554223228286297, guid: b4ec85ebe552cce43b9f60ba08bb9986,
+        type: 3}
+      propertyPath: m_Layer
+      value: 10
+      objectReference: {fileID: 0}
+    - target: {fileID: 6673812251784679946, guid: b4ec85ebe552cce43b9f60ba08bb9986,
+        type: 3}
+      propertyPath: m_Layer
+      value: 10
+      objectReference: {fileID: 0}
+    - target: {fileID: 6680753928887217791, guid: b4ec85ebe552cce43b9f60ba08bb9986,
+        type: 3}
+      propertyPath: m_Layer
+      value: 10
+      objectReference: {fileID: 0}
+    - target: {fileID: 6734502290242813021, guid: b4ec85ebe552cce43b9f60ba08bb9986,
+        type: 3}
+      propertyPath: m_Layer
+      value: 10
+      objectReference: {fileID: 0}
+    - target: {fileID: 6752078568186245689, guid: b4ec85ebe552cce43b9f60ba08bb9986,
+        type: 3}
+      propertyPath: m_Layer
+      value: 10
+      objectReference: {fileID: 0}
     - target: {fileID: 6870507228783895701, guid: b4ec85ebe552cce43b9f60ba08bb9986,
         type: 3}
       propertyPath: m_IsActive
       value: 0
       objectReference: {fileID: 0}
+    - target: {fileID: 6895519836946660466, guid: b4ec85ebe552cce43b9f60ba08bb9986,
+        type: 3}
+      propertyPath: m_Layer
+      value: 10
+      objectReference: {fileID: 0}
+    - target: {fileID: 7098414106505093929, guid: b4ec85ebe552cce43b9f60ba08bb9986,
+        type: 3}
+      propertyPath: m_Layer
+      value: 10
+      objectReference: {fileID: 0}
+    - target: {fileID: 7222973110233394740, guid: b4ec85ebe552cce43b9f60ba08bb9986,
+        type: 3}
+      propertyPath: m_Layer
+      value: 10
+      objectReference: {fileID: 0}
+    - target: {fileID: 7302104811526953291, guid: b4ec85ebe552cce43b9f60ba08bb9986,
+        type: 3}
+      propertyPath: m_Layer
+      value: 10
+      objectReference: {fileID: 0}
     - target: {fileID: 7391006145443133968, guid: b4ec85ebe552cce43b9f60ba08bb9986,
         type: 3}
       propertyPath: m_Name
       value: bestudoPreview
+      objectReference: {fileID: 0}
+    - target: {fileID: 7391006145443133968, guid: b4ec85ebe552cce43b9f60ba08bb9986,
+        type: 3}
+      propertyPath: m_Layer
+      value: 10
+      objectReference: {fileID: 0}
+    - target: {fileID: 7515499819373790471, guid: b4ec85ebe552cce43b9f60ba08bb9986,
+        type: 3}
+      propertyPath: m_Layer
+      value: 10
+      objectReference: {fileID: 0}
+    - target: {fileID: 7638386810029375807, guid: b4ec85ebe552cce43b9f60ba08bb9986,
+        type: 3}
+      propertyPath: m_Layer
+      value: 10
+      objectReference: {fileID: 0}
+    - target: {fileID: 7670716683908614584, guid: b4ec85ebe552cce43b9f60ba08bb9986,
+        type: 3}
+      propertyPath: m_Layer
+      value: 10
       objectReference: {fileID: 0}
     - target: {fileID: 7769416934539659082, guid: b4ec85ebe552cce43b9f60ba08bb9986,
         type: 3}
@@ -198,6 +538,51 @@ PrefabInstance:
         type: 3}
       propertyPath: m_LocalEulerAnglesHint.z
       value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8064949246855180129, guid: b4ec85ebe552cce43b9f60ba08bb9986,
+        type: 3}
+      propertyPath: m_Layer
+      value: 10
+      objectReference: {fileID: 0}
+    - target: {fileID: 8325491111895991598, guid: b4ec85ebe552cce43b9f60ba08bb9986,
+        type: 3}
+      propertyPath: m_Layer
+      value: 10
+      objectReference: {fileID: 0}
+    - target: {fileID: 8421047604887229994, guid: b4ec85ebe552cce43b9f60ba08bb9986,
+        type: 3}
+      propertyPath: m_Layer
+      value: 10
+      objectReference: {fileID: 0}
+    - target: {fileID: 8608961806933758232, guid: b4ec85ebe552cce43b9f60ba08bb9986,
+        type: 3}
+      propertyPath: m_Layer
+      value: 10
+      objectReference: {fileID: 0}
+    - target: {fileID: 8621420465478205045, guid: b4ec85ebe552cce43b9f60ba08bb9986,
+        type: 3}
+      propertyPath: m_Layer
+      value: 10
+      objectReference: {fileID: 0}
+    - target: {fileID: 8702705418253873324, guid: b4ec85ebe552cce43b9f60ba08bb9986,
+        type: 3}
+      propertyPath: m_Layer
+      value: 10
+      objectReference: {fileID: 0}
+    - target: {fileID: 8842740590289119861, guid: b4ec85ebe552cce43b9f60ba08bb9986,
+        type: 3}
+      propertyPath: m_Layer
+      value: 10
+      objectReference: {fileID: 0}
+    - target: {fileID: 9048635264789460938, guid: b4ec85ebe552cce43b9f60ba08bb9986,
+        type: 3}
+      propertyPath: m_Layer
+      value: 10
+      objectReference: {fileID: 0}
+    - target: {fileID: 9217222266754968570, guid: b4ec85ebe552cce43b9f60ba08bb9986,
+        type: 3}
+      propertyPath: m_Layer
+      value: 10
       objectReference: {fileID: 0}
     m_RemovedComponents: []
     m_RemovedGameObjects:

--- a/Assets/Characters/Players/Bo.prefab
+++ b/Assets/Characters/Players/Bo.prefab
@@ -9,7 +9,7 @@ GameObject:
   serializedVersion: 6
   m_Component:
   - component: {fileID: 702709430963348804}
-  m_Layer: 0
+  m_Layer: 10
   m_Name: ItemDropPoint
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -228,10 +228,25 @@ PrefabInstance:
     serializedVersion: 3
     m_TransformParent: {fileID: 5895599378835331091}
     m_Modifications:
+    - target: {fileID: 34827733439072697, guid: 0b928052c13542449b8895b510343b22,
+        type: 3}
+      propertyPath: m_Layer
+      value: 10
+      objectReference: {fileID: 0}
     - target: {fileID: 74436002125552078, guid: 0b928052c13542449b8895b510343b22,
         type: 3}
       propertyPath: m_LocalPosition.y
       value: -0.34
+      objectReference: {fileID: 0}
+    - target: {fileID: 107407228046965037, guid: 0b928052c13542449b8895b510343b22,
+        type: 3}
+      propertyPath: m_Layer
+      value: 10
+      objectReference: {fileID: 0}
+    - target: {fileID: 198784162459068546, guid: 0b928052c13542449b8895b510343b22,
+        type: 3}
+      propertyPath: m_Layer
+      value: 10
       objectReference: {fileID: 0}
     - target: {fileID: 337811752465549027, guid: 0b928052c13542449b8895b510343b22,
         type: 3}
@@ -248,15 +263,225 @@ PrefabInstance:
       propertyPath: m_LocalPosition.z
       value: -0.159
       objectReference: {fileID: 0}
+    - target: {fileID: 397604673008471327, guid: 0b928052c13542449b8895b510343b22,
+        type: 3}
+      propertyPath: m_Layer
+      value: 10
+      objectReference: {fileID: 0}
+    - target: {fileID: 447505949102300101, guid: 0b928052c13542449b8895b510343b22,
+        type: 3}
+      propertyPath: m_Layer
+      value: 10
+      objectReference: {fileID: 0}
+    - target: {fileID: 682300920324648194, guid: 0b928052c13542449b8895b510343b22,
+        type: 3}
+      propertyPath: m_Layer
+      value: 10
+      objectReference: {fileID: 0}
     - target: {fileID: 867995327683482841, guid: 0b928052c13542449b8895b510343b22,
         type: 3}
       propertyPath: m_IsActive
       value: 0
       objectReference: {fileID: 0}
+    - target: {fileID: 1027986524623341454, guid: 0b928052c13542449b8895b510343b22,
+        type: 3}
+      propertyPath: m_Layer
+      value: 10
+      objectReference: {fileID: 0}
+    - target: {fileID: 1207026873249464838, guid: 0b928052c13542449b8895b510343b22,
+        type: 3}
+      propertyPath: m_Layer
+      value: 10
+      objectReference: {fileID: 0}
+    - target: {fileID: 1339894718818415345, guid: 0b928052c13542449b8895b510343b22,
+        type: 3}
+      propertyPath: m_Layer
+      value: 10
+      objectReference: {fileID: 0}
+    - target: {fileID: 1445494263314144114, guid: 0b928052c13542449b8895b510343b22,
+        type: 3}
+      propertyPath: m_Layer
+      value: 10
+      objectReference: {fileID: 0}
+    - target: {fileID: 1710881157210485778, guid: 0b928052c13542449b8895b510343b22,
+        type: 3}
+      propertyPath: m_Layer
+      value: 10
+      objectReference: {fileID: 0}
+    - target: {fileID: 1754942827802787288, guid: 0b928052c13542449b8895b510343b22,
+        type: 3}
+      propertyPath: m_Layer
+      value: 10
+      objectReference: {fileID: 0}
+    - target: {fileID: 2063922305260996812, guid: 0b928052c13542449b8895b510343b22,
+        type: 3}
+      propertyPath: m_Layer
+      value: 10
+      objectReference: {fileID: 0}
+    - target: {fileID: 2146596376357900691, guid: 0b928052c13542449b8895b510343b22,
+        type: 3}
+      propertyPath: m_Layer
+      value: 10
+      objectReference: {fileID: 0}
+    - target: {fileID: 2188142287846642600, guid: 0b928052c13542449b8895b510343b22,
+        type: 3}
+      propertyPath: m_Layer
+      value: 10
+      objectReference: {fileID: 0}
+    - target: {fileID: 2473523736519420614, guid: 0b928052c13542449b8895b510343b22,
+        type: 3}
+      propertyPath: m_Layer
+      value: 10
+      objectReference: {fileID: 0}
+    - target: {fileID: 2777914823550887901, guid: 0b928052c13542449b8895b510343b22,
+        type: 3}
+      propertyPath: m_Layer
+      value: 10
+      objectReference: {fileID: 0}
+    - target: {fileID: 2947630732265164977, guid: 0b928052c13542449b8895b510343b22,
+        type: 3}
+      propertyPath: m_Layer
+      value: 10
+      objectReference: {fileID: 0}
+    - target: {fileID: 2972484450369805005, guid: 0b928052c13542449b8895b510343b22,
+        type: 3}
+      propertyPath: m_Layer
+      value: 10
+      objectReference: {fileID: 0}
+    - target: {fileID: 3120124820722352737, guid: 0b928052c13542449b8895b510343b22,
+        type: 3}
+      propertyPath: m_Layer
+      value: 10
+      objectReference: {fileID: 0}
+    - target: {fileID: 3309888961942023410, guid: 0b928052c13542449b8895b510343b22,
+        type: 3}
+      propertyPath: m_Layer
+      value: 10
+      objectReference: {fileID: 0}
+    - target: {fileID: 3329527783325172553, guid: 0b928052c13542449b8895b510343b22,
+        type: 3}
+      propertyPath: m_Layer
+      value: 10
+      objectReference: {fileID: 0}
+    - target: {fileID: 3347141268622140784, guid: 0b928052c13542449b8895b510343b22,
+        type: 3}
+      propertyPath: m_Layer
+      value: 10
+      objectReference: {fileID: 0}
+    - target: {fileID: 3413161505927197130, guid: 0b928052c13542449b8895b510343b22,
+        type: 3}
+      propertyPath: m_Layer
+      value: 10
+      objectReference: {fileID: 0}
+    - target: {fileID: 3462802301009193978, guid: 0b928052c13542449b8895b510343b22,
+        type: 3}
+      propertyPath: m_Layer
+      value: 10
+      objectReference: {fileID: 0}
+    - target: {fileID: 3771838450246724650, guid: 0b928052c13542449b8895b510343b22,
+        type: 3}
+      propertyPath: m_Layer
+      value: 10
+      objectReference: {fileID: 0}
+    - target: {fileID: 3832369569242811118, guid: 0b928052c13542449b8895b510343b22,
+        type: 3}
+      propertyPath: m_Layer
+      value: 10
+      objectReference: {fileID: 0}
+    - target: {fileID: 3945177969475757402, guid: 0b928052c13542449b8895b510343b22,
+        type: 3}
+      propertyPath: m_Layer
+      value: 10
+      objectReference: {fileID: 0}
+    - target: {fileID: 4057850434182945457, guid: 0b928052c13542449b8895b510343b22,
+        type: 3}
+      propertyPath: m_Layer
+      value: 10
+      objectReference: {fileID: 0}
     - target: {fileID: 4071763425662547718, guid: 0b928052c13542449b8895b510343b22,
         type: 3}
       propertyPath: m_IsActive
       value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4104377084710496931, guid: 0b928052c13542449b8895b510343b22,
+        type: 3}
+      propertyPath: m_Layer
+      value: 10
+      objectReference: {fileID: 0}
+    - target: {fileID: 4270276012552218383, guid: 0b928052c13542449b8895b510343b22,
+        type: 3}
+      propertyPath: m_Layer
+      value: 10
+      objectReference: {fileID: 0}
+    - target: {fileID: 4302086622762956967, guid: 0b928052c13542449b8895b510343b22,
+        type: 3}
+      propertyPath: m_Layer
+      value: 10
+      objectReference: {fileID: 0}
+    - target: {fileID: 4344470917857247853, guid: 0b928052c13542449b8895b510343b22,
+        type: 3}
+      propertyPath: m_Layer
+      value: 10
+      objectReference: {fileID: 0}
+    - target: {fileID: 4429717877566208703, guid: 0b928052c13542449b8895b510343b22,
+        type: 3}
+      propertyPath: m_Layer
+      value: 10
+      objectReference: {fileID: 0}
+    - target: {fileID: 4551319116190974148, guid: 0b928052c13542449b8895b510343b22,
+        type: 3}
+      propertyPath: m_Layer
+      value: 10
+      objectReference: {fileID: 0}
+    - target: {fileID: 4722705691681331363, guid: 0b928052c13542449b8895b510343b22,
+        type: 3}
+      propertyPath: m_Layer
+      value: 10
+      objectReference: {fileID: 0}
+    - target: {fileID: 4898766317120537210, guid: 0b928052c13542449b8895b510343b22,
+        type: 3}
+      propertyPath: m_Layer
+      value: 10
+      objectReference: {fileID: 0}
+    - target: {fileID: 4962797881575284677, guid: 0b928052c13542449b8895b510343b22,
+        type: 3}
+      propertyPath: m_Layer
+      value: 10
+      objectReference: {fileID: 0}
+    - target: {fileID: 5090885504992412661, guid: 0b928052c13542449b8895b510343b22,
+        type: 3}
+      propertyPath: m_Layer
+      value: 10
+      objectReference: {fileID: 0}
+    - target: {fileID: 5388070676436987169, guid: 0b928052c13542449b8895b510343b22,
+        type: 3}
+      propertyPath: m_Layer
+      value: 10
+      objectReference: {fileID: 0}
+    - target: {fileID: 5635549679752263959, guid: 0b928052c13542449b8895b510343b22,
+        type: 3}
+      propertyPath: m_Layer
+      value: 10
+      objectReference: {fileID: 0}
+    - target: {fileID: 5686115079148164730, guid: 0b928052c13542449b8895b510343b22,
+        type: 3}
+      propertyPath: m_Layer
+      value: 10
+      objectReference: {fileID: 0}
+    - target: {fileID: 5836727727625579784, guid: 0b928052c13542449b8895b510343b22,
+        type: 3}
+      propertyPath: m_Layer
+      value: 10
+      objectReference: {fileID: 0}
+    - target: {fileID: 5998671125528912311, guid: 0b928052c13542449b8895b510343b22,
+        type: 3}
+      propertyPath: m_Layer
+      value: 10
+      objectReference: {fileID: 0}
+    - target: {fileID: 6002546102045681968, guid: 0b928052c13542449b8895b510343b22,
+        type: 3}
+      propertyPath: m_Layer
+      value: 10
       objectReference: {fileID: 0}
     - target: {fileID: 6094957954013825189, guid: 0b928052c13542449b8895b510343b22,
         type: 3}
@@ -308,15 +533,180 @@ PrefabInstance:
       propertyPath: m_LocalEulerAnglesHint.z
       value: 0
       objectReference: {fileID: 0}
+    - target: {fileID: 6242032144254322542, guid: 0b928052c13542449b8895b510343b22,
+        type: 3}
+      propertyPath: m_Layer
+      value: 10
+      objectReference: {fileID: 0}
+    - target: {fileID: 6615490643594152742, guid: 0b928052c13542449b8895b510343b22,
+        type: 3}
+      propertyPath: m_Layer
+      value: 10
+      objectReference: {fileID: 0}
+    - target: {fileID: 6636645685883973956, guid: 0b928052c13542449b8895b510343b22,
+        type: 3}
+      propertyPath: m_Layer
+      value: 10
+      objectReference: {fileID: 0}
+    - target: {fileID: 6733290958070924859, guid: 0b928052c13542449b8895b510343b22,
+        type: 3}
+      propertyPath: m_Layer
+      value: 10
+      objectReference: {fileID: 0}
     - target: {fileID: 6908085716926845471, guid: 0b928052c13542449b8895b510343b22,
         type: 3}
       propertyPath: m_Name
       value: BoPreview
       objectReference: {fileID: 0}
+    - target: {fileID: 6908085716926845471, guid: 0b928052c13542449b8895b510343b22,
+        type: 3}
+      propertyPath: m_Layer
+      value: 10
+      objectReference: {fileID: 0}
+    - target: {fileID: 7005007707216960839, guid: 0b928052c13542449b8895b510343b22,
+        type: 3}
+      propertyPath: m_Layer
+      value: 10
+      objectReference: {fileID: 0}
+    - target: {fileID: 7047708861024767961, guid: 0b928052c13542449b8895b510343b22,
+        type: 3}
+      propertyPath: m_Layer
+      value: 10
+      objectReference: {fileID: 0}
+    - target: {fileID: 7120539706877697366, guid: 0b928052c13542449b8895b510343b22,
+        type: 3}
+      propertyPath: m_Layer
+      value: 10
+      objectReference: {fileID: 0}
+    - target: {fileID: 7221963538422043730, guid: 0b928052c13542449b8895b510343b22,
+        type: 3}
+      propertyPath: m_Layer
+      value: 10
+      objectReference: {fileID: 0}
+    - target: {fileID: 7275670867043342902, guid: 0b928052c13542449b8895b510343b22,
+        type: 3}
+      propertyPath: m_Layer
+      value: 10
+      objectReference: {fileID: 0}
+    - target: {fileID: 7337057961736714757, guid: 0b928052c13542449b8895b510343b22,
+        type: 3}
+      propertyPath: m_Layer
+      value: 10
+      objectReference: {fileID: 0}
+    - target: {fileID: 7421260882558014589, guid: 0b928052c13542449b8895b510343b22,
+        type: 3}
+      propertyPath: m_Layer
+      value: 10
+      objectReference: {fileID: 0}
+    - target: {fileID: 7602271120969794820, guid: 0b928052c13542449b8895b510343b22,
+        type: 3}
+      propertyPath: m_Layer
+      value: 10
+      objectReference: {fileID: 0}
+    - target: {fileID: 7625377165121433063, guid: 0b928052c13542449b8895b510343b22,
+        type: 3}
+      propertyPath: m_Layer
+      value: 10
+      objectReference: {fileID: 0}
+    - target: {fileID: 7640606933437284991, guid: 0b928052c13542449b8895b510343b22,
+        type: 3}
+      propertyPath: m_Layer
+      value: 10
+      objectReference: {fileID: 0}
+    - target: {fileID: 7799860367103963283, guid: 0b928052c13542449b8895b510343b22,
+        type: 3}
+      propertyPath: m_Layer
+      value: 10
+      objectReference: {fileID: 0}
+    - target: {fileID: 7889844476806981250, guid: 0b928052c13542449b8895b510343b22,
+        type: 3}
+      propertyPath: m_Layer
+      value: 10
+      objectReference: {fileID: 0}
+    - target: {fileID: 7979119642138729955, guid: 0b928052c13542449b8895b510343b22,
+        type: 3}
+      propertyPath: m_Layer
+      value: 10
+      objectReference: {fileID: 0}
+    - target: {fileID: 8083447826719485416, guid: 0b928052c13542449b8895b510343b22,
+        type: 3}
+      propertyPath: m_Layer
+      value: 10
+      objectReference: {fileID: 0}
+    - target: {fileID: 8141549184425714864, guid: 0b928052c13542449b8895b510343b22,
+        type: 3}
+      propertyPath: m_Layer
+      value: 10
+      objectReference: {fileID: 0}
+    - target: {fileID: 8321227092344280387, guid: 0b928052c13542449b8895b510343b22,
+        type: 3}
+      propertyPath: m_Layer
+      value: 10
+      objectReference: {fileID: 0}
+    - target: {fileID: 8396948125389483331, guid: 0b928052c13542449b8895b510343b22,
+        type: 3}
+      propertyPath: m_Layer
+      value: 10
+      objectReference: {fileID: 0}
+    - target: {fileID: 8427782778740349283, guid: 0b928052c13542449b8895b510343b22,
+        type: 3}
+      propertyPath: m_Layer
+      value: 10
+      objectReference: {fileID: 0}
+    - target: {fileID: 8461115085601776294, guid: 0b928052c13542449b8895b510343b22,
+        type: 3}
+      propertyPath: m_Layer
+      value: 10
+      objectReference: {fileID: 0}
+    - target: {fileID: 8552542176337510991, guid: 0b928052c13542449b8895b510343b22,
+        type: 3}
+      propertyPath: m_Layer
+      value: 10
+      objectReference: {fileID: 0}
+    - target: {fileID: 8576267558305675671, guid: 0b928052c13542449b8895b510343b22,
+        type: 3}
+      propertyPath: m_Layer
+      value: 10
+      objectReference: {fileID: 0}
+    - target: {fileID: 8690290820928169315, guid: 0b928052c13542449b8895b510343b22,
+        type: 3}
+      propertyPath: m_Layer
+      value: 10
+      objectReference: {fileID: 0}
+    - target: {fileID: 8713846484320501770, guid: 0b928052c13542449b8895b510343b22,
+        type: 3}
+      propertyPath: m_Layer
+      value: 10
+      objectReference: {fileID: 0}
+    - target: {fileID: 8737708622523034958, guid: 0b928052c13542449b8895b510343b22,
+        type: 3}
+      propertyPath: m_Layer
+      value: 10
+      objectReference: {fileID: 0}
+    - target: {fileID: 8742958481027848892, guid: 0b928052c13542449b8895b510343b22,
+        type: 3}
+      propertyPath: m_Layer
+      value: 10
+      objectReference: {fileID: 0}
+    - target: {fileID: 8819546384891176343, guid: 0b928052c13542449b8895b510343b22,
+        type: 3}
+      propertyPath: m_Layer
+      value: 10
+      objectReference: {fileID: 0}
     - target: {fileID: 8837015768468824921, guid: 0b928052c13542449b8895b510343b22,
         type: 3}
       propertyPath: m_IsActive
       value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8873811052771154570, guid: 0b928052c13542449b8895b510343b22,
+        type: 3}
+      propertyPath: m_Layer
+      value: 10
+      objectReference: {fileID: 0}
+    - target: {fileID: 9055152483104164552, guid: 0b928052c13542449b8895b510343b22,
+        type: 3}
+      propertyPath: m_Layer
+      value: 10
       objectReference: {fileID: 0}
     m_RemovedComponents: []
     m_RemovedGameObjects: []

--- a/Assets/Characters/Players/Buck.prefab
+++ b/Assets/Characters/Players/Buck.prefab
@@ -9,7 +9,7 @@ GameObject:
   serializedVersion: 6
   m_Component:
   - component: {fileID: 4445919475007377619}
-  m_Layer: 0
+  m_Layer: 10
   m_Name: ItemDropPoint
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -228,15 +228,215 @@ PrefabInstance:
     serializedVersion: 3
     m_TransformParent: {fileID: 4202899985560269545}
     m_Modifications:
+    - target: {fileID: 34081947762334633, guid: a80bca964294b924c81b9f88fbf209e9,
+        type: 3}
+      propertyPath: m_Layer
+      value: 10
+      objectReference: {fileID: 0}
+    - target: {fileID: 107867263039384381, guid: a80bca964294b924c81b9f88fbf209e9,
+        type: 3}
+      propertyPath: m_Layer
+      value: 10
+      objectReference: {fileID: 0}
+    - target: {fileID: 398073433224896271, guid: a80bca964294b924c81b9f88fbf209e9,
+        type: 3}
+      propertyPath: m_Layer
+      value: 10
+      objectReference: {fileID: 0}
+    - target: {fileID: 447952789952956885, guid: a80bca964294b924c81b9f88fbf209e9,
+        type: 3}
+      propertyPath: m_Layer
+      value: 10
+      objectReference: {fileID: 0}
+    - target: {fileID: 683047307285380882, guid: a80bca964294b924c81b9f88fbf209e9,
+        type: 3}
+      propertyPath: m_Layer
+      value: 10
+      objectReference: {fileID: 0}
+    - target: {fileID: 1028662081073141150, guid: a80bca964294b924c81b9f88fbf209e9,
+        type: 3}
+      propertyPath: m_Layer
+      value: 10
+      objectReference: {fileID: 0}
+    - target: {fileID: 1115155315638456008, guid: a80bca964294b924c81b9f88fbf209e9,
+        type: 3}
+      propertyPath: m_Layer
+      value: 10
+      objectReference: {fileID: 0}
+    - target: {fileID: 1207693064516522006, guid: a80bca964294b924c81b9f88fbf209e9,
+        type: 3}
+      propertyPath: m_Layer
+      value: 10
+      objectReference: {fileID: 0}
+    - target: {fileID: 1340645383507845345, guid: a80bca964294b924c81b9f88fbf209e9,
+        type: 3}
+      propertyPath: m_Layer
+      value: 10
+      objectReference: {fileID: 0}
+    - target: {fileID: 1445026173118777698, guid: a80bca964294b924c81b9f88fbf209e9,
+        type: 3}
+      propertyPath: m_Layer
+      value: 10
+      objectReference: {fileID: 0}
+    - target: {fileID: 1710501045117380098, guid: a80bca964294b924c81b9f88fbf209e9,
+        type: 3}
+      propertyPath: m_Layer
+      value: 10
+      objectReference: {fileID: 0}
+    - target: {fileID: 1754259594099208136, guid: a80bca964294b924c81b9f88fbf209e9,
+        type: 3}
+      propertyPath: m_Layer
+      value: 10
+      objectReference: {fileID: 0}
+    - target: {fileID: 2064382132012260060, guid: a80bca964294b924c81b9f88fbf209e9,
+        type: 3}
+      propertyPath: m_Layer
+      value: 10
+      objectReference: {fileID: 0}
+    - target: {fileID: 2146124641874428803, guid: a80bca964294b924c81b9f88fbf209e9,
+        type: 3}
+      propertyPath: m_Layer
+      value: 10
+      objectReference: {fileID: 0}
+    - target: {fileID: 2188601169705386424, guid: a80bca964294b924c81b9f88fbf209e9,
+        type: 3}
+      propertyPath: m_Layer
+      value: 10
+      objectReference: {fileID: 0}
+    - target: {fileID: 2472782142739577046, guid: a80bca964294b924c81b9f88fbf209e9,
+        type: 3}
+      propertyPath: m_Layer
+      value: 10
+      objectReference: {fileID: 0}
+    - target: {fileID: 2778593607670412749, guid: a80bca964294b924c81b9f88fbf209e9,
+        type: 3}
+      propertyPath: m_Layer
+      value: 10
+      objectReference: {fileID: 0}
+    - target: {fileID: 2948371709723919009, guid: a80bca964294b924c81b9f88fbf209e9,
+        type: 3}
+      propertyPath: m_Layer
+      value: 10
+      objectReference: {fileID: 0}
+    - target: {fileID: 2973163148657117405, guid: a80bca964294b924c81b9f88fbf209e9,
+        type: 3}
+      propertyPath: m_Layer
+      value: 10
+      objectReference: {fileID: 0}
+    - target: {fileID: 3120508574948544625, guid: a80bca964294b924c81b9f88fbf209e9,
+        type: 3}
+      propertyPath: m_Layer
+      value: 10
+      objectReference: {fileID: 0}
+    - target: {fileID: 3309504174720106210, guid: a80bca964294b924c81b9f88fbf209e9,
+        type: 3}
+      propertyPath: m_Layer
+      value: 10
+      objectReference: {fileID: 0}
+    - target: {fileID: 3329977731578548569, guid: a80bca964294b924c81b9f88fbf209e9,
+        type: 3}
+      propertyPath: m_Layer
+      value: 10
+      objectReference: {fileID: 0}
+    - target: {fileID: 3346669053104273248, guid: a80bca964294b924c81b9f88fbf209e9,
+        type: 3}
+      propertyPath: m_Layer
+      value: 10
+      objectReference: {fileID: 0}
+    - target: {fileID: 3413537975945176026, guid: a80bca964294b924c81b9f88fbf209e9,
+        type: 3}
+      propertyPath: m_Layer
+      value: 10
+      objectReference: {fileID: 0}
+    - target: {fileID: 3462413392765630954, guid: a80bca964294b924c81b9f88fbf209e9,
+        type: 3}
+      propertyPath: m_Layer
+      value: 10
+      objectReference: {fileID: 0}
+    - target: {fileID: 3772589237410135610, guid: a80bca964294b924c81b9f88fbf209e9,
+        type: 3}
+      propertyPath: m_Layer
+      value: 10
+      objectReference: {fileID: 0}
+    - target: {fileID: 3831966436065761534, guid: a80bca964294b924c81b9f88fbf209e9,
+        type: 3}
+      propertyPath: m_Layer
+      value: 10
+      objectReference: {fileID: 0}
     - target: {fileID: 3917259395968192454, guid: a80bca964294b924c81b9f88fbf209e9,
         type: 3}
       propertyPath: m_IsActive
       value: 0
       objectReference: {fileID: 0}
+    - target: {fileID: 3945919150871541578, guid: a80bca964294b924c81b9f88fbf209e9,
+        type: 3}
+      propertyPath: m_Layer
+      value: 10
+      objectReference: {fileID: 0}
+    - target: {fileID: 4058534372330227873, guid: a80bca964294b924c81b9f88fbf209e9,
+        type: 3}
+      propertyPath: m_Layer
+      value: 10
+      objectReference: {fileID: 0}
+    - target: {fileID: 4104753760821803187, guid: a80bca964294b924c81b9f88fbf209e9,
+        type: 3}
+      propertyPath: m_Layer
+      value: 10
+      objectReference: {fileID: 0}
+    - target: {fileID: 4269904559123248415, guid: a80bca964294b924c81b9f88fbf209e9,
+        type: 3}
+      propertyPath: m_Layer
+      value: 10
+      objectReference: {fileID: 0}
+    - target: {fileID: 4302831033980136119, guid: a80bca964294b924c81b9f88fbf209e9,
+        type: 3}
+      propertyPath: m_Layer
+      value: 10
+      objectReference: {fileID: 0}
+    - target: {fileID: 4343730303323525245, guid: a80bca964294b924c81b9f88fbf209e9,
+        type: 3}
+      propertyPath: m_Layer
+      value: 10
+      objectReference: {fileID: 0}
+    - target: {fileID: 4430180884675602607, guid: a80bca964294b924c81b9f88fbf209e9,
+        type: 3}
+      propertyPath: m_Layer
+      value: 10
+      objectReference: {fileID: 0}
+    - target: {fileID: 4551774063862043348, guid: a80bca964294b924c81b9f88fbf209e9,
+        type: 3}
+      propertyPath: m_Layer
+      value: 10
+      objectReference: {fileID: 0}
     - target: {fileID: 4680428073989388358, guid: a80bca964294b924c81b9f88fbf209e9,
         type: 3}
       propertyPath: m_IsActive
       value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4722241052419214003, guid: a80bca964294b924c81b9f88fbf209e9,
+        type: 3}
+      propertyPath: m_Layer
+      value: 10
+      objectReference: {fileID: 0}
+    - target: {fileID: 4898021905908961386, guid: a80bca964294b924c81b9f88fbf209e9,
+        type: 3}
+      propertyPath: m_Layer
+      value: 10
+      objectReference: {fileID: 0}
+    - target: {fileID: 4962342933904510421, guid: a80bca964294b924c81b9f88fbf209e9,
+        type: 3}
+      propertyPath: m_Layer
+      value: 10
+      objectReference: {fileID: 0}
+    - target: {fileID: 5090434953290011109, guid: a80bca964294b924c81b9f88fbf209e9,
+        type: 3}
+      propertyPath: m_Layer
+      value: 10
+      objectReference: {fileID: 0}
+    - target: {fileID: 5387689722538557233, guid: a80bca964294b924c81b9f88fbf209e9,
+        type: 3}
+      propertyPath: m_Layer
+      value: 10
       objectReference: {fileID: 0}
     - target: {fileID: 5618230130965181777, guid: a80bca964294b924c81b9f88fbf209e9,
         type: 3}
@@ -252,6 +452,26 @@ PrefabInstance:
         type: 3}
       propertyPath: m_LocalPosition.z
       value: -0.066
+      objectReference: {fileID: 0}
+    - target: {fileID: 5636202608166464263, guid: a80bca964294b924c81b9f88fbf209e9,
+        type: 3}
+      propertyPath: m_Layer
+      value: 10
+      objectReference: {fileID: 0}
+    - target: {fileID: 5686794481807459434, guid: a80bca964294b924c81b9f88fbf209e9,
+        type: 3}
+      propertyPath: m_Layer
+      value: 10
+      objectReference: {fileID: 0}
+    - target: {fileID: 5837393044866662168, guid: a80bca964294b924c81b9f88fbf209e9,
+        type: 3}
+      propertyPath: m_Layer
+      value: 10
+      objectReference: {fileID: 0}
+    - target: {fileID: 5997986981300958119, guid: a80bca964294b924c81b9f88fbf209e9,
+        type: 3}
+      propertyPath: m_Layer
+      value: 10
       objectReference: {fileID: 0}
     - target: {fileID: 6095354971156961973, guid: a80bca964294b924c81b9f88fbf209e9,
         type: 3}
@@ -303,15 +523,180 @@ PrefabInstance:
       propertyPath: m_LocalEulerAnglesHint.z
       value: 0
       objectReference: {fileID: 0}
+    - target: {fileID: 6242703575379481982, guid: a80bca964294b924c81b9f88fbf209e9,
+        type: 3}
+      propertyPath: m_Layer
+      value: 10
+      objectReference: {fileID: 0}
+    - target: {fileID: 6614766727891704118, guid: a80bca964294b924c81b9f88fbf209e9,
+        type: 3}
+      propertyPath: m_Layer
+      value: 10
+      objectReference: {fileID: 0}
+    - target: {fileID: 6636252980887249748, guid: a80bca964294b924c81b9f88fbf209e9,
+        type: 3}
+      propertyPath: m_Layer
+      value: 10
+      objectReference: {fileID: 0}
+    - target: {fileID: 6733966153812382763, guid: a80bca964294b924c81b9f88fbf209e9,
+        type: 3}
+      propertyPath: m_Layer
+      value: 10
+      objectReference: {fileID: 0}
     - target: {fileID: 6907639614740660239, guid: a80bca964294b924c81b9f88fbf209e9,
         type: 3}
       propertyPath: m_Name
       value: Buck_BowmanPreview
       objectReference: {fileID: 0}
+    - target: {fileID: 6907639614740660239, guid: a80bca964294b924c81b9f88fbf209e9,
+        type: 3}
+      propertyPath: m_Layer
+      value: 10
+      objectReference: {fileID: 0}
+    - target: {fileID: 7004337253197352791, guid: a80bca964294b924c81b9f88fbf209e9,
+        type: 3}
+      propertyPath: m_Layer
+      value: 10
+      objectReference: {fileID: 0}
+    - target: {fileID: 7047239669164432841, guid: a80bca964294b924c81b9f88fbf209e9,
+        type: 3}
+      propertyPath: m_Layer
+      value: 10
+      objectReference: {fileID: 0}
+    - target: {fileID: 7121197997627871046, guid: a80bca964294b924c81b9f88fbf209e9,
+        type: 3}
+      propertyPath: m_Layer
+      value: 10
+      objectReference: {fileID: 0}
+    - target: {fileID: 7222436149135885890, guid: a80bca964294b924c81b9f88fbf209e9,
+        type: 3}
+      propertyPath: m_Layer
+      value: 10
+      objectReference: {fileID: 0}
+    - target: {fileID: 7276355612635662374, guid: a80bca964294b924c81b9f88fbf209e9,
+        type: 3}
+      propertyPath: m_Layer
+      value: 10
+      objectReference: {fileID: 0}
+    - target: {fileID: 7336603132246616085, guid: a80bca964294b924c81b9f88fbf209e9,
+        type: 3}
+      propertyPath: m_Layer
+      value: 10
+      objectReference: {fileID: 0}
+    - target: {fileID: 7421707396982507117, guid: a80bca964294b924c81b9f88fbf209e9,
+        type: 3}
+      propertyPath: m_Layer
+      value: 10
+      objectReference: {fileID: 0}
+    - target: {fileID: 7602673979207898900, guid: a80bca964294b924c81b9f88fbf209e9,
+        type: 3}
+      propertyPath: m_Layer
+      value: 10
+      objectReference: {fileID: 0}
+    - target: {fileID: 7624707260847456247, guid: a80bca964294b924c81b9f88fbf209e9,
+        type: 3}
+      propertyPath: m_Layer
+      value: 10
+      objectReference: {fileID: 0}
+    - target: {fileID: 7641004914734125167, guid: a80bca964294b924c81b9f88fbf209e9,
+        type: 3}
+      propertyPath: m_Layer
+      value: 10
+      objectReference: {fileID: 0}
+    - target: {fileID: 7799114529890525827, guid: a80bca964294b924c81b9f88fbf209e9,
+        type: 3}
+      propertyPath: m_Layer
+      value: 10
+      objectReference: {fileID: 0}
+    - target: {fileID: 7889450326623728786, guid: a80bca964294b924c81b9f88fbf209e9,
+        type: 3}
+      propertyPath: m_Layer
+      value: 10
+      objectReference: {fileID: 0}
+    - target: {fileID: 7978454326979989491, guid: a80bca964294b924c81b9f88fbf209e9,
+        type: 3}
+      propertyPath: m_Layer
+      value: 10
+      objectReference: {fileID: 0}
+    - target: {fileID: 8082978377169108984, guid: a80bca964294b924c81b9f88fbf209e9,
+        type: 3}
+      propertyPath: m_Layer
+      value: 10
+      objectReference: {fileID: 0}
+    - target: {fileID: 8142007997498373792, guid: a80bca964294b924c81b9f88fbf209e9,
+        type: 3}
+      propertyPath: m_Layer
+      value: 10
+      objectReference: {fileID: 0}
+    - target: {fileID: 8320471821243565907, guid: a80bca964294b924c81b9f88fbf209e9,
+        type: 3}
+      propertyPath: m_Layer
+      value: 10
+      objectReference: {fileID: 0}
     - target: {fileID: 8394229136891698073, guid: a80bca964294b924c81b9f88fbf209e9,
         type: 3}
       propertyPath: m_IsActive
       value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8396219534623620947, guid: a80bca964294b924c81b9f88fbf209e9,
+        type: 3}
+      propertyPath: m_Layer
+      value: 10
+      objectReference: {fileID: 0}
+    - target: {fileID: 8428435243289955187, guid: a80bca964294b924c81b9f88fbf209e9,
+        type: 3}
+      propertyPath: m_Layer
+      value: 10
+      objectReference: {fileID: 0}
+    - target: {fileID: 8460369985039593654, guid: a80bca964294b924c81b9f88fbf209e9,
+        type: 3}
+      propertyPath: m_Layer
+      value: 10
+      objectReference: {fileID: 0}
+    - target: {fileID: 8552921944833626207, guid: a80bca964294b924c81b9f88fbf209e9,
+        type: 3}
+      propertyPath: m_Layer
+      value: 10
+      objectReference: {fileID: 0}
+    - target: {fileID: 8577012160651291527, guid: a80bca964294b924c81b9f88fbf209e9,
+        type: 3}
+      propertyPath: m_Layer
+      value: 10
+      objectReference: {fileID: 0}
+    - target: {fileID: 8689892908344915827, guid: a80bca964294b924c81b9f88fbf209e9,
+        type: 3}
+      propertyPath: m_Layer
+      value: 10
+      objectReference: {fileID: 0}
+    - target: {fileID: 8714293548576576026, guid: a80bca964294b924c81b9f88fbf209e9,
+        type: 3}
+      propertyPath: m_Layer
+      value: 10
+      objectReference: {fileID: 0}
+    - target: {fileID: 8737050660405329758, guid: a80bca964294b924c81b9f88fbf209e9,
+        type: 3}
+      propertyPath: m_Layer
+      value: 10
+      objectReference: {fileID: 0}
+    - target: {fileID: 8743620551281477804, guid: a80bca964294b924c81b9f88fbf209e9,
+        type: 3}
+      propertyPath: m_Layer
+      value: 10
+      objectReference: {fileID: 0}
+    - target: {fileID: 8820295814780008327, guid: a80bca964294b924c81b9f88fbf209e9,
+        type: 3}
+      propertyPath: m_Layer
+      value: 10
+      objectReference: {fileID: 0}
+    - target: {fileID: 8873413812347947162, guid: a80bca964294b924c81b9f88fbf209e9,
+        type: 3}
+      propertyPath: m_Layer
+      value: 10
+      objectReference: {fileID: 0}
+    - target: {fileID: 9054755122357000408, guid: a80bca964294b924c81b9f88fbf209e9,
+        type: 3}
+      propertyPath: m_Layer
+      value: 10
       objectReference: {fileID: 0}
     m_RemovedComponents: []
     m_RemovedGameObjects: []

--- a/Assets/Characters/Players/Desmesmert.prefab
+++ b/Assets/Characters/Players/Desmesmert.prefab
@@ -9,7 +9,7 @@ GameObject:
   serializedVersion: 6
   m_Component:
   - component: {fileID: 5929376166363156451}
-  m_Layer: 0
+  m_Layer: 10
   m_Name: ItemDropPoint
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -39,15 +39,215 @@ PrefabInstance:
     serializedVersion: 3
     m_TransformParent: {fileID: 3671070984082133610}
     m_Modifications:
+    - target: {fileID: 14043732088914215, guid: c09ecc6dde7f64147ab535ff494cdf46,
+        type: 3}
+      propertyPath: m_Layer
+      value: 10
+      objectReference: {fileID: 0}
+    - target: {fileID: 52237238419085859, guid: c09ecc6dde7f64147ab535ff494cdf46,
+        type: 3}
+      propertyPath: m_Layer
+      value: 10
+      objectReference: {fileID: 0}
+    - target: {fileID: 88771983011971861, guid: c09ecc6dde7f64147ab535ff494cdf46,
+        type: 3}
+      propertyPath: m_Layer
+      value: 10
+      objectReference: {fileID: 0}
     - target: {fileID: 116201035624789559, guid: c09ecc6dde7f64147ab535ff494cdf46,
         type: 3}
       propertyPath: m_IsActive
       value: 0
       objectReference: {fileID: 0}
+    - target: {fileID: 118759948733172933, guid: c09ecc6dde7f64147ab535ff494cdf46,
+        type: 3}
+      propertyPath: m_Layer
+      value: 10
+      objectReference: {fileID: 0}
+    - target: {fileID: 122096086724618276, guid: c09ecc6dde7f64147ab535ff494cdf46,
+        type: 3}
+      propertyPath: m_Layer
+      value: 10
+      objectReference: {fileID: 0}
+    - target: {fileID: 155266822928475384, guid: c09ecc6dde7f64147ab535ff494cdf46,
+        type: 3}
+      propertyPath: m_Layer
+      value: 10
+      objectReference: {fileID: 0}
+    - target: {fileID: 277191038048642828, guid: c09ecc6dde7f64147ab535ff494cdf46,
+        type: 3}
+      propertyPath: m_Layer
+      value: 10
+      objectReference: {fileID: 0}
+    - target: {fileID: 347989916918634971, guid: c09ecc6dde7f64147ab535ff494cdf46,
+        type: 3}
+      propertyPath: m_Layer
+      value: 10
+      objectReference: {fileID: 0}
+    - target: {fileID: 386690626674346085, guid: c09ecc6dde7f64147ab535ff494cdf46,
+        type: 3}
+      propertyPath: m_Layer
+      value: 10
+      objectReference: {fileID: 0}
+    - target: {fileID: 442613339908650803, guid: c09ecc6dde7f64147ab535ff494cdf46,
+        type: 3}
+      propertyPath: m_Layer
+      value: 10
+      objectReference: {fileID: 0}
+    - target: {fileID: 559759847582165916, guid: c09ecc6dde7f64147ab535ff494cdf46,
+        type: 3}
+      propertyPath: m_Layer
+      value: 10
+      objectReference: {fileID: 0}
+    - target: {fileID: 570023660385213123, guid: c09ecc6dde7f64147ab535ff494cdf46,
+        type: 3}
+      propertyPath: m_Layer
+      value: 10
+      objectReference: {fileID: 0}
+    - target: {fileID: 661963269655984699, guid: c09ecc6dde7f64147ab535ff494cdf46,
+        type: 3}
+      propertyPath: m_Layer
+      value: 10
+      objectReference: {fileID: 0}
+    - target: {fileID: 690209201875956196, guid: c09ecc6dde7f64147ab535ff494cdf46,
+        type: 3}
+      propertyPath: m_Layer
+      value: 10
+      objectReference: {fileID: 0}
+    - target: {fileID: 691005215853817005, guid: c09ecc6dde7f64147ab535ff494cdf46,
+        type: 3}
+      propertyPath: m_Layer
+      value: 10
+      objectReference: {fileID: 0}
+    - target: {fileID: 981492131594974446, guid: c09ecc6dde7f64147ab535ff494cdf46,
+        type: 3}
+      propertyPath: m_Layer
+      value: 10
+      objectReference: {fileID: 0}
+    - target: {fileID: 1040870716963624780, guid: c09ecc6dde7f64147ab535ff494cdf46,
+        type: 3}
+      propertyPath: m_Layer
+      value: 10
+      objectReference: {fileID: 0}
+    - target: {fileID: 1064328702786551942, guid: c09ecc6dde7f64147ab535ff494cdf46,
+        type: 3}
+      propertyPath: m_Layer
+      value: 10
+      objectReference: {fileID: 0}
+    - target: {fileID: 1107100362751470244, guid: c09ecc6dde7f64147ab535ff494cdf46,
+        type: 3}
+      propertyPath: m_Layer
+      value: 10
+      objectReference: {fileID: 0}
+    - target: {fileID: 1248365963940672019, guid: c09ecc6dde7f64147ab535ff494cdf46,
+        type: 3}
+      propertyPath: m_Layer
+      value: 10
+      objectReference: {fileID: 0}
+    - target: {fileID: 1257695524764266326, guid: c09ecc6dde7f64147ab535ff494cdf46,
+        type: 3}
+      propertyPath: m_Layer
+      value: 10
+      objectReference: {fileID: 0}
+    - target: {fileID: 1699005245522012936, guid: c09ecc6dde7f64147ab535ff494cdf46,
+        type: 3}
+      propertyPath: m_Layer
+      value: 10
+      objectReference: {fileID: 0}
+    - target: {fileID: 1773033890609300186, guid: c09ecc6dde7f64147ab535ff494cdf46,
+        type: 3}
+      propertyPath: m_Layer
+      value: 10
+      objectReference: {fileID: 0}
+    - target: {fileID: 1790848372980643860, guid: c09ecc6dde7f64147ab535ff494cdf46,
+        type: 3}
+      propertyPath: m_Layer
+      value: 10
+      objectReference: {fileID: 0}
+    - target: {fileID: 1825858878300338114, guid: c09ecc6dde7f64147ab535ff494cdf46,
+        type: 3}
+      propertyPath: m_Layer
+      value: 10
+      objectReference: {fileID: 0}
+    - target: {fileID: 1886803140847301256, guid: c09ecc6dde7f64147ab535ff494cdf46,
+        type: 3}
+      propertyPath: m_Layer
+      value: 10
+      objectReference: {fileID: 0}
+    - target: {fileID: 2105020169124900493, guid: c09ecc6dde7f64147ab535ff494cdf46,
+        type: 3}
+      propertyPath: m_Layer
+      value: 10
+      objectReference: {fileID: 0}
+    - target: {fileID: 2133844435629352159, guid: c09ecc6dde7f64147ab535ff494cdf46,
+        type: 3}
+      propertyPath: m_Layer
+      value: 10
+      objectReference: {fileID: 0}
+    - target: {fileID: 2167090649413999503, guid: c09ecc6dde7f64147ab535ff494cdf46,
+        type: 3}
+      propertyPath: m_Layer
+      value: 10
+      objectReference: {fileID: 0}
+    - target: {fileID: 2437942848452383805, guid: c09ecc6dde7f64147ab535ff494cdf46,
+        type: 3}
+      propertyPath: m_Layer
+      value: 10
+      objectReference: {fileID: 0}
+    - target: {fileID: 2563542866365643798, guid: c09ecc6dde7f64147ab535ff494cdf46,
+        type: 3}
+      propertyPath: m_Layer
+      value: 10
+      objectReference: {fileID: 0}
+    - target: {fileID: 2610073960194721754, guid: c09ecc6dde7f64147ab535ff494cdf46,
+        type: 3}
+      propertyPath: m_Layer
+      value: 10
+      objectReference: {fileID: 0}
+    - target: {fileID: 2673556879083398413, guid: c09ecc6dde7f64147ab535ff494cdf46,
+        type: 3}
+      propertyPath: m_Layer
+      value: 10
+      objectReference: {fileID: 0}
+    - target: {fileID: 2824391062824275584, guid: c09ecc6dde7f64147ab535ff494cdf46,
+        type: 3}
+      propertyPath: m_Layer
+      value: 10
+      objectReference: {fileID: 0}
+    - target: {fileID: 3205359524940593419, guid: c09ecc6dde7f64147ab535ff494cdf46,
+        type: 3}
+      propertyPath: m_Layer
+      value: 10
+      objectReference: {fileID: 0}
+    - target: {fileID: 3310249716659695977, guid: c09ecc6dde7f64147ab535ff494cdf46,
+        type: 3}
+      propertyPath: m_Layer
+      value: 10
+      objectReference: {fileID: 0}
+    - target: {fileID: 3315299402510945502, guid: c09ecc6dde7f64147ab535ff494cdf46,
+        type: 3}
+      propertyPath: m_Layer
+      value: 10
+      objectReference: {fileID: 0}
+    - target: {fileID: 3600183874146057066, guid: c09ecc6dde7f64147ab535ff494cdf46,
+        type: 3}
+      propertyPath: m_Layer
+      value: 10
+      objectReference: {fileID: 0}
+    - target: {fileID: 3804044755378046575, guid: c09ecc6dde7f64147ab535ff494cdf46,
+        type: 3}
+      propertyPath: m_Layer
+      value: 10
+      objectReference: {fileID: 0}
     - target: {fileID: 3825427847761909224, guid: c09ecc6dde7f64147ab535ff494cdf46,
         type: 3}
       propertyPath: m_IsActive
       value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3917024603502120622, guid: c09ecc6dde7f64147ab535ff494cdf46,
+        type: 3}
+      propertyPath: m_Layer
+      value: 10
       objectReference: {fileID: 0}
     - target: {fileID: 4041250987527641343, guid: c09ecc6dde7f64147ab535ff494cdf46,
         type: 3}
@@ -89,6 +289,21 @@ PrefabInstance:
       propertyPath: m_LocalEulerAnglesHint.x
       value: 2
       objectReference: {fileID: 0}
+    - target: {fileID: 4078618317963004493, guid: c09ecc6dde7f64147ab535ff494cdf46,
+        type: 3}
+      propertyPath: m_Layer
+      value: 10
+      objectReference: {fileID: 0}
+    - target: {fileID: 4247809936140614696, guid: c09ecc6dde7f64147ab535ff494cdf46,
+        type: 3}
+      propertyPath: m_Layer
+      value: 10
+      objectReference: {fileID: 0}
+    - target: {fileID: 4383640753137979724, guid: c09ecc6dde7f64147ab535ff494cdf46,
+        type: 3}
+      propertyPath: m_Layer
+      value: 10
+      objectReference: {fileID: 0}
     - target: {fileID: 4444277148711176146, guid: c09ecc6dde7f64147ab535ff494cdf46,
         type: 3}
       propertyPath: m_LocalPosition.x
@@ -104,10 +319,30 @@ PrefabInstance:
       propertyPath: m_LocalPosition.z
       value: -0.064
       objectReference: {fileID: 0}
+    - target: {fileID: 4545435102953739306, guid: c09ecc6dde7f64147ab535ff494cdf46,
+        type: 3}
+      propertyPath: m_Layer
+      value: 10
+      objectReference: {fileID: 0}
+    - target: {fileID: 4806653344200175076, guid: c09ecc6dde7f64147ab535ff494cdf46,
+        type: 3}
+      propertyPath: m_Layer
+      value: 10
+      objectReference: {fileID: 0}
     - target: {fileID: 4881471535202017896, guid: c09ecc6dde7f64147ab535ff494cdf46,
         type: 3}
       propertyPath: m_IsActive
       value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4920729067665529912, guid: c09ecc6dde7f64147ab535ff494cdf46,
+        type: 3}
+      propertyPath: m_Layer
+      value: 10
+      objectReference: {fileID: 0}
+    - target: {fileID: 4960028695814727960, guid: c09ecc6dde7f64147ab535ff494cdf46,
+        type: 3}
+      propertyPath: m_Layer
+      value: 10
       objectReference: {fileID: 0}
     - target: {fileID: 5257293764725438674, guid: c09ecc6dde7f64147ab535ff494cdf46,
         type: 3}
@@ -124,10 +359,80 @@ PrefabInstance:
       propertyPath: m_LocalPosition.z
       value: -0.068
       objectReference: {fileID: 0}
+    - target: {fileID: 5303642770124570462, guid: c09ecc6dde7f64147ab535ff494cdf46,
+        type: 3}
+      propertyPath: m_Layer
+      value: 10
+      objectReference: {fileID: 0}
+    - target: {fileID: 5432493231710511919, guid: c09ecc6dde7f64147ab535ff494cdf46,
+        type: 3}
+      propertyPath: m_Layer
+      value: 10
+      objectReference: {fileID: 0}
+    - target: {fileID: 5451953374483198985, guid: c09ecc6dde7f64147ab535ff494cdf46,
+        type: 3}
+      propertyPath: m_Layer
+      value: 10
+      objectReference: {fileID: 0}
+    - target: {fileID: 5688315640741307031, guid: c09ecc6dde7f64147ab535ff494cdf46,
+        type: 3}
+      propertyPath: m_Layer
+      value: 10
+      objectReference: {fileID: 0}
+    - target: {fileID: 5779880736769987842, guid: c09ecc6dde7f64147ab535ff494cdf46,
+        type: 3}
+      propertyPath: m_Layer
+      value: 10
+      objectReference: {fileID: 0}
+    - target: {fileID: 5865241476952152821, guid: c09ecc6dde7f64147ab535ff494cdf46,
+        type: 3}
+      propertyPath: m_Layer
+      value: 10
+      objectReference: {fileID: 0}
+    - target: {fileID: 5883962420531337158, guid: c09ecc6dde7f64147ab535ff494cdf46,
+        type: 3}
+      propertyPath: m_Layer
+      value: 10
+      objectReference: {fileID: 0}
+    - target: {fileID: 6157218058924847671, guid: c09ecc6dde7f64147ab535ff494cdf46,
+        type: 3}
+      propertyPath: m_Layer
+      value: 10
+      objectReference: {fileID: 0}
+    - target: {fileID: 6201885585070319307, guid: c09ecc6dde7f64147ab535ff494cdf46,
+        type: 3}
+      propertyPath: m_Layer
+      value: 10
+      objectReference: {fileID: 0}
     - target: {fileID: 6208265770907095726, guid: c09ecc6dde7f64147ab535ff494cdf46,
         type: 3}
       propertyPath: m_Name
       value: DesmesmertPreview
+      objectReference: {fileID: 0}
+    - target: {fileID: 6208265770907095726, guid: c09ecc6dde7f64147ab535ff494cdf46,
+        type: 3}
+      propertyPath: m_Layer
+      value: 10
+      objectReference: {fileID: 0}
+    - target: {fileID: 6276003045535952887, guid: c09ecc6dde7f64147ab535ff494cdf46,
+        type: 3}
+      propertyPath: m_Layer
+      value: 10
+      objectReference: {fileID: 0}
+    - target: {fileID: 6341861666677850492, guid: c09ecc6dde7f64147ab535ff494cdf46,
+        type: 3}
+      propertyPath: m_Layer
+      value: 10
+      objectReference: {fileID: 0}
+    - target: {fileID: 6632770598266383818, guid: c09ecc6dde7f64147ab535ff494cdf46,
+        type: 3}
+      propertyPath: m_Layer
+      value: 10
+      objectReference: {fileID: 0}
+    - target: {fileID: 6654077171738278203, guid: c09ecc6dde7f64147ab535ff494cdf46,
+        type: 3}
+      propertyPath: m_Layer
+      value: 10
       objectReference: {fileID: 0}
     - target: {fileID: 6950014148171571389, guid: c09ecc6dde7f64147ab535ff494cdf46,
         type: 3}
@@ -178,6 +483,81 @@ PrefabInstance:
         type: 3}
       propertyPath: m_LocalEulerAnglesHint.z
       value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7077000304705667623, guid: c09ecc6dde7f64147ab535ff494cdf46,
+        type: 3}
+      propertyPath: m_Layer
+      value: 10
+      objectReference: {fileID: 0}
+    - target: {fileID: 7243450993891017500, guid: c09ecc6dde7f64147ab535ff494cdf46,
+        type: 3}
+      propertyPath: m_Layer
+      value: 10
+      objectReference: {fileID: 0}
+    - target: {fileID: 7280055795938051217, guid: c09ecc6dde7f64147ab535ff494cdf46,
+        type: 3}
+      propertyPath: m_Layer
+      value: 10
+      objectReference: {fileID: 0}
+    - target: {fileID: 7324833347754985688, guid: c09ecc6dde7f64147ab535ff494cdf46,
+        type: 3}
+      propertyPath: m_Layer
+      value: 10
+      objectReference: {fileID: 0}
+    - target: {fileID: 7673427230115161933, guid: c09ecc6dde7f64147ab535ff494cdf46,
+        type: 3}
+      propertyPath: m_Layer
+      value: 10
+      objectReference: {fileID: 0}
+    - target: {fileID: 7822881605769049245, guid: c09ecc6dde7f64147ab535ff494cdf46,
+        type: 3}
+      propertyPath: m_Layer
+      value: 10
+      objectReference: {fileID: 0}
+    - target: {fileID: 8059191017283622709, guid: c09ecc6dde7f64147ab535ff494cdf46,
+        type: 3}
+      propertyPath: m_Layer
+      value: 10
+      objectReference: {fileID: 0}
+    - target: {fileID: 8111283661002323268, guid: c09ecc6dde7f64147ab535ff494cdf46,
+        type: 3}
+      propertyPath: m_Layer
+      value: 10
+      objectReference: {fileID: 0}
+    - target: {fileID: 8413487246521307432, guid: c09ecc6dde7f64147ab535ff494cdf46,
+        type: 3}
+      propertyPath: m_Layer
+      value: 10
+      objectReference: {fileID: 0}
+    - target: {fileID: 8473802636530913841, guid: c09ecc6dde7f64147ab535ff494cdf46,
+        type: 3}
+      propertyPath: m_Layer
+      value: 10
+      objectReference: {fileID: 0}
+    - target: {fileID: 8650745383490177300, guid: c09ecc6dde7f64147ab535ff494cdf46,
+        type: 3}
+      propertyPath: m_Layer
+      value: 10
+      objectReference: {fileID: 0}
+    - target: {fileID: 8829400196032593929, guid: c09ecc6dde7f64147ab535ff494cdf46,
+        type: 3}
+      propertyPath: m_Layer
+      value: 10
+      objectReference: {fileID: 0}
+    - target: {fileID: 8863188103421892097, guid: c09ecc6dde7f64147ab535ff494cdf46,
+        type: 3}
+      propertyPath: m_Layer
+      value: 10
+      objectReference: {fileID: 0}
+    - target: {fileID: 8870174459640842158, guid: c09ecc6dde7f64147ab535ff494cdf46,
+        type: 3}
+      propertyPath: m_Layer
+      value: 10
+      objectReference: {fileID: 0}
+    - target: {fileID: 9145368059360183728, guid: c09ecc6dde7f64147ab535ff494cdf46,
+        type: 3}
+      propertyPath: m_Layer
+      value: 10
       objectReference: {fileID: 0}
     m_RemovedComponents: []
     m_RemovedGameObjects: []

--- a/Assets/Characters/Players/Doug.prefab
+++ b/Assets/Characters/Players/Doug.prefab
@@ -9,7 +9,7 @@ GameObject:
   serializedVersion: 6
   m_Component:
   - component: {fileID: 9082519234852248032}
-  m_Layer: 0
+  m_Layer: 10
   m_Name: ItemDropPoint
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -39,6 +39,61 @@ PrefabInstance:
     serializedVersion: 3
     m_TransformParent: {fileID: 2932940715433677650}
     m_Modifications:
+    - target: {fileID: 14162099976203523, guid: 328a1197c4ce3a34db1c0dffcd3f291a,
+        type: 3}
+      propertyPath: m_Layer
+      value: 10
+      objectReference: {fileID: 0}
+    - target: {fileID: 310989321220745402, guid: 328a1197c4ce3a34db1c0dffcd3f291a,
+        type: 3}
+      propertyPath: m_Layer
+      value: 10
+      objectReference: {fileID: 0}
+    - target: {fileID: 414822912338849565, guid: 328a1197c4ce3a34db1c0dffcd3f291a,
+        type: 3}
+      propertyPath: m_Layer
+      value: 10
+      objectReference: {fileID: 0}
+    - target: {fileID: 421316430163279538, guid: 328a1197c4ce3a34db1c0dffcd3f291a,
+        type: 3}
+      propertyPath: m_Layer
+      value: 10
+      objectReference: {fileID: 0}
+    - target: {fileID: 492317905557168551, guid: 328a1197c4ce3a34db1c0dffcd3f291a,
+        type: 3}
+      propertyPath: m_Layer
+      value: 10
+      objectReference: {fileID: 0}
+    - target: {fileID: 627204384615372316, guid: 328a1197c4ce3a34db1c0dffcd3f291a,
+        type: 3}
+      propertyPath: m_Layer
+      value: 10
+      objectReference: {fileID: 0}
+    - target: {fileID: 727957527113398683, guid: 328a1197c4ce3a34db1c0dffcd3f291a,
+        type: 3}
+      propertyPath: m_Layer
+      value: 10
+      objectReference: {fileID: 0}
+    - target: {fileID: 810772226649717378, guid: 328a1197c4ce3a34db1c0dffcd3f291a,
+        type: 3}
+      propertyPath: m_Layer
+      value: 10
+      objectReference: {fileID: 0}
+    - target: {fileID: 1029527793374715383, guid: 328a1197c4ce3a34db1c0dffcd3f291a,
+        type: 3}
+      propertyPath: m_Layer
+      value: 10
+      objectReference: {fileID: 0}
+    - target: {fileID: 1229324465472634758, guid: 328a1197c4ce3a34db1c0dffcd3f291a,
+        type: 3}
+      propertyPath: m_Layer
+      value: 10
+      objectReference: {fileID: 0}
+    - target: {fileID: 1317578654008073262, guid: 328a1197c4ce3a34db1c0dffcd3f291a,
+        type: 3}
+      propertyPath: m_Layer
+      value: 10
+      objectReference: {fileID: 0}
     - target: {fileID: 1362192345970046908, guid: 328a1197c4ce3a34db1c0dffcd3f291a,
         type: 3}
       propertyPath: m_LocalPosition.x
@@ -69,6 +124,11 @@ PrefabInstance:
       propertyPath: m_LocalEulerAnglesHint.x
       value: 0
       objectReference: {fileID: 0}
+    - target: {fileID: 1487862400640487422, guid: 328a1197c4ce3a34db1c0dffcd3f291a,
+        type: 3}
+      propertyPath: m_Layer
+      value: 10
+      objectReference: {fileID: 0}
     - target: {fileID: 1684113581770287249, guid: 328a1197c4ce3a34db1c0dffcd3f291a,
         type: 3}
       propertyPath: m_LocalPosition.x
@@ -88,6 +148,26 @@ PrefabInstance:
         type: 3}
       propertyPath: m_IsActive
       value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1899788813532130223, guid: 328a1197c4ce3a34db1c0dffcd3f291a,
+        type: 3}
+      propertyPath: m_Layer
+      value: 10
+      objectReference: {fileID: 0}
+    - target: {fileID: 1981450307386466411, guid: 328a1197c4ce3a34db1c0dffcd3f291a,
+        type: 3}
+      propertyPath: m_Layer
+      value: 10
+      objectReference: {fileID: 0}
+    - target: {fileID: 2008460013226273826, guid: 328a1197c4ce3a34db1c0dffcd3f291a,
+        type: 3}
+      propertyPath: m_Layer
+      value: 10
+      objectReference: {fileID: 0}
+    - target: {fileID: 2084605711074257556, guid: 328a1197c4ce3a34db1c0dffcd3f291a,
+        type: 3}
+      propertyPath: m_Layer
+      value: 10
       objectReference: {fileID: 0}
     - target: {fileID: 2210113595175356430, guid: 328a1197c4ce3a34db1c0dffcd3f291a,
         type: 3}
@@ -139,15 +219,205 @@ PrefabInstance:
       propertyPath: m_LocalEulerAnglesHint.z
       value: 0
       objectReference: {fileID: 0}
+    - target: {fileID: 2486137076529631624, guid: 328a1197c4ce3a34db1c0dffcd3f291a,
+        type: 3}
+      propertyPath: m_Layer
+      value: 10
+      objectReference: {fileID: 0}
+    - target: {fileID: 2509870753228670329, guid: 328a1197c4ce3a34db1c0dffcd3f291a,
+        type: 3}
+      propertyPath: m_Layer
+      value: 10
+      objectReference: {fileID: 0}
+    - target: {fileID: 2799653492808280527, guid: 328a1197c4ce3a34db1c0dffcd3f291a,
+        type: 3}
+      propertyPath: m_Layer
+      value: 10
+      objectReference: {fileID: 0}
+    - target: {fileID: 2938890702156697208, guid: 328a1197c4ce3a34db1c0dffcd3f291a,
+        type: 3}
+      propertyPath: m_Layer
+      value: 10
+      objectReference: {fileID: 0}
     - target: {fileID: 2950068046219622941, guid: 328a1197c4ce3a34db1c0dffcd3f291a,
         type: 3}
       propertyPath: m_Name
       value: DougPreview
       objectReference: {fileID: 0}
+    - target: {fileID: 2950068046219622941, guid: 328a1197c4ce3a34db1c0dffcd3f291a,
+        type: 3}
+      propertyPath: m_Layer
+      value: 10
+      objectReference: {fileID: 0}
+    - target: {fileID: 3008501401630558020, guid: 328a1197c4ce3a34db1c0dffcd3f291a,
+        type: 3}
+      propertyPath: m_Layer
+      value: 10
+      objectReference: {fileID: 0}
+    - target: {fileID: 3146426944368745092, guid: 328a1197c4ce3a34db1c0dffcd3f291a,
+        type: 3}
+      propertyPath: m_Layer
+      value: 10
+      objectReference: {fileID: 0}
     - target: {fileID: 3375043318821848665, guid: 328a1197c4ce3a34db1c0dffcd3f291a,
         type: 3}
       propertyPath: m_IsActive
       value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3381866290905398705, guid: 328a1197c4ce3a34db1c0dffcd3f291a,
+        type: 3}
+      propertyPath: m_Layer
+      value: 10
+      objectReference: {fileID: 0}
+    - target: {fileID: 3418380778734649205, guid: 328a1197c4ce3a34db1c0dffcd3f291a,
+        type: 3}
+      propertyPath: m_Layer
+      value: 10
+      objectReference: {fileID: 0}
+    - target: {fileID: 3439916261094076998, guid: 328a1197c4ce3a34db1c0dffcd3f291a,
+        type: 3}
+      propertyPath: m_Layer
+      value: 10
+      objectReference: {fileID: 0}
+    - target: {fileID: 3470159296613567012, guid: 328a1197c4ce3a34db1c0dffcd3f291a,
+        type: 3}
+      propertyPath: m_Layer
+      value: 10
+      objectReference: {fileID: 0}
+    - target: {fileID: 3872137311891573660, guid: 328a1197c4ce3a34db1c0dffcd3f291a,
+        type: 3}
+      propertyPath: m_Layer
+      value: 10
+      objectReference: {fileID: 0}
+    - target: {fileID: 3981988487427725293, guid: 328a1197c4ce3a34db1c0dffcd3f291a,
+        type: 3}
+      propertyPath: m_Layer
+      value: 10
+      objectReference: {fileID: 0}
+    - target: {fileID: 4182999906555986347, guid: 328a1197c4ce3a34db1c0dffcd3f291a,
+        type: 3}
+      propertyPath: m_Layer
+      value: 10
+      objectReference: {fileID: 0}
+    - target: {fileID: 4220293506354148491, guid: 328a1197c4ce3a34db1c0dffcd3f291a,
+        type: 3}
+      propertyPath: m_Layer
+      value: 10
+      objectReference: {fileID: 0}
+    - target: {fileID: 4353896921446368599, guid: 328a1197c4ce3a34db1c0dffcd3f291a,
+        type: 3}
+      propertyPath: m_Layer
+      value: 10
+      objectReference: {fileID: 0}
+    - target: {fileID: 4741215866281196697, guid: 328a1197c4ce3a34db1c0dffcd3f291a,
+        type: 3}
+      propertyPath: m_Layer
+      value: 10
+      objectReference: {fileID: 0}
+    - target: {fileID: 4759563303476525567, guid: 328a1197c4ce3a34db1c0dffcd3f291a,
+        type: 3}
+      propertyPath: m_Layer
+      value: 10
+      objectReference: {fileID: 0}
+    - target: {fileID: 4912247627418817691, guid: 328a1197c4ce3a34db1c0dffcd3f291a,
+        type: 3}
+      propertyPath: m_Layer
+      value: 10
+      objectReference: {fileID: 0}
+    - target: {fileID: 5062791799493550846, guid: 328a1197c4ce3a34db1c0dffcd3f291a,
+        type: 3}
+      propertyPath: m_Layer
+      value: 10
+      objectReference: {fileID: 0}
+    - target: {fileID: 5225475803737843229, guid: 328a1197c4ce3a34db1c0dffcd3f291a,
+        type: 3}
+      propertyPath: m_Layer
+      value: 10
+      objectReference: {fileID: 0}
+    - target: {fileID: 5337364919207325404, guid: 328a1197c4ce3a34db1c0dffcd3f291a,
+        type: 3}
+      propertyPath: m_Layer
+      value: 10
+      objectReference: {fileID: 0}
+    - target: {fileID: 5705748165334160345, guid: 328a1197c4ce3a34db1c0dffcd3f291a,
+        type: 3}
+      propertyPath: m_Layer
+      value: 10
+      objectReference: {fileID: 0}
+    - target: {fileID: 5826180915721544813, guid: 328a1197c4ce3a34db1c0dffcd3f291a,
+        type: 3}
+      propertyPath: m_Layer
+      value: 10
+      objectReference: {fileID: 0}
+    - target: {fileID: 5954662575625687480, guid: 328a1197c4ce3a34db1c0dffcd3f291a,
+        type: 3}
+      propertyPath: m_Layer
+      value: 10
+      objectReference: {fileID: 0}
+    - target: {fileID: 5992269124750957018, guid: 328a1197c4ce3a34db1c0dffcd3f291a,
+        type: 3}
+      propertyPath: m_Layer
+      value: 10
+      objectReference: {fileID: 0}
+    - target: {fileID: 6479218769505363507, guid: 328a1197c4ce3a34db1c0dffcd3f291a,
+        type: 3}
+      propertyPath: m_Layer
+      value: 10
+      objectReference: {fileID: 0}
+    - target: {fileID: 6548330483399503721, guid: 328a1197c4ce3a34db1c0dffcd3f291a,
+        type: 3}
+      propertyPath: m_Layer
+      value: 10
+      objectReference: {fileID: 0}
+    - target: {fileID: 6612109163400367550, guid: 328a1197c4ce3a34db1c0dffcd3f291a,
+        type: 3}
+      propertyPath: m_Layer
+      value: 10
+      objectReference: {fileID: 0}
+    - target: {fileID: 6722474801319974053, guid: 328a1197c4ce3a34db1c0dffcd3f291a,
+        type: 3}
+      propertyPath: m_Layer
+      value: 10
+      objectReference: {fileID: 0}
+    - target: {fileID: 6849376400499129486, guid: 328a1197c4ce3a34db1c0dffcd3f291a,
+        type: 3}
+      propertyPath: m_Layer
+      value: 10
+      objectReference: {fileID: 0}
+    - target: {fileID: 6974812379487974204, guid: 328a1197c4ce3a34db1c0dffcd3f291a,
+        type: 3}
+      propertyPath: m_Layer
+      value: 10
+      objectReference: {fileID: 0}
+    - target: {fileID: 7152982450717936748, guid: 328a1197c4ce3a34db1c0dffcd3f291a,
+        type: 3}
+      propertyPath: m_Layer
+      value: 10
+      objectReference: {fileID: 0}
+    - target: {fileID: 7200700694905226814, guid: 328a1197c4ce3a34db1c0dffcd3f291a,
+        type: 3}
+      propertyPath: m_Layer
+      value: 10
+      objectReference: {fileID: 0}
+    - target: {fileID: 7275506807253998139, guid: 328a1197c4ce3a34db1c0dffcd3f291a,
+        type: 3}
+      propertyPath: m_Layer
+      value: 10
+      objectReference: {fileID: 0}
+    - target: {fileID: 7350666833786835111, guid: 328a1197c4ce3a34db1c0dffcd3f291a,
+        type: 3}
+      propertyPath: m_Layer
+      value: 10
+      objectReference: {fileID: 0}
+    - target: {fileID: 7368904374677662313, guid: 328a1197c4ce3a34db1c0dffcd3f291a,
+        type: 3}
+      propertyPath: m_Layer
+      value: 10
+      objectReference: {fileID: 0}
+    - target: {fileID: 7461988943766052721, guid: 328a1197c4ce3a34db1c0dffcd3f291a,
+        type: 3}
+      propertyPath: m_Layer
+      value: 10
       objectReference: {fileID: 0}
     - target: {fileID: 7475954416412641468, guid: 328a1197c4ce3a34db1c0dffcd3f291a,
         type: 3}
@@ -174,10 +444,70 @@ PrefabInstance:
       propertyPath: m_LocalEulerAnglesHint.x
       value: 0
       objectReference: {fileID: 0}
+    - target: {fileID: 7587610813739402171, guid: 328a1197c4ce3a34db1c0dffcd3f291a,
+        type: 3}
+      propertyPath: m_Layer
+      value: 10
+      objectReference: {fileID: 0}
     - target: {fileID: 7850966305283346950, guid: 328a1197c4ce3a34db1c0dffcd3f291a,
         type: 3}
       propertyPath: m_IsActive
       value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8037686922012514976, guid: 328a1197c4ce3a34db1c0dffcd3f291a,
+        type: 3}
+      propertyPath: m_Layer
+      value: 10
+      objectReference: {fileID: 0}
+    - target: {fileID: 8047005628111570917, guid: 328a1197c4ce3a34db1c0dffcd3f291a,
+        type: 3}
+      propertyPath: m_Layer
+      value: 10
+      objectReference: {fileID: 0}
+    - target: {fileID: 8078840637075269685, guid: 328a1197c4ce3a34db1c0dffcd3f291a,
+        type: 3}
+      propertyPath: m_Layer
+      value: 10
+      objectReference: {fileID: 0}
+    - target: {fileID: 8118131917288505343, guid: 328a1197c4ce3a34db1c0dffcd3f291a,
+        type: 3}
+      propertyPath: m_Layer
+      value: 10
+      objectReference: {fileID: 0}
+    - target: {fileID: 8306461209176824925, guid: 328a1197c4ce3a34db1c0dffcd3f291a,
+        type: 3}
+      propertyPath: m_Layer
+      value: 10
+      objectReference: {fileID: 0}
+    - target: {fileID: 8596406376874465623, guid: 328a1197c4ce3a34db1c0dffcd3f291a,
+        type: 3}
+      propertyPath: m_Layer
+      value: 10
+      objectReference: {fileID: 0}
+    - target: {fileID: 8644461054198780552, guid: 328a1197c4ce3a34db1c0dffcd3f291a,
+        type: 3}
+      propertyPath: m_Layer
+      value: 10
+      objectReference: {fileID: 0}
+    - target: {fileID: 8718113380128153472, guid: 328a1197c4ce3a34db1c0dffcd3f291a,
+        type: 3}
+      propertyPath: m_Layer
+      value: 10
+      objectReference: {fileID: 0}
+    - target: {fileID: 8726890915545580335, guid: 328a1197c4ce3a34db1c0dffcd3f291a,
+        type: 3}
+      propertyPath: m_Layer
+      value: 10
+      objectReference: {fileID: 0}
+    - target: {fileID: 8732953493210460784, guid: 328a1197c4ce3a34db1c0dffcd3f291a,
+        type: 3}
+      propertyPath: m_Layer
+      value: 10
+      objectReference: {fileID: 0}
+    - target: {fileID: 8794616847239393640, guid: 328a1197c4ce3a34db1c0dffcd3f291a,
+        type: 3}
+      propertyPath: m_Layer
+      value: 10
       objectReference: {fileID: 0}
     - target: {fileID: 8851018966591942081, guid: 328a1197c4ce3a34db1c0dffcd3f291a,
         type: 3}
@@ -193,6 +523,46 @@ PrefabInstance:
         type: 3}
       propertyPath: m_LocalPosition.z
       value: -0.045
+      objectReference: {fileID: 0}
+    - target: {fileID: 8900593368655012054, guid: 328a1197c4ce3a34db1c0dffcd3f291a,
+        type: 3}
+      propertyPath: m_Layer
+      value: 10
+      objectReference: {fileID: 0}
+    - target: {fileID: 9006937344381209675, guid: 328a1197c4ce3a34db1c0dffcd3f291a,
+        type: 3}
+      propertyPath: m_Layer
+      value: 10
+      objectReference: {fileID: 0}
+    - target: {fileID: 9007278791659835327, guid: 328a1197c4ce3a34db1c0dffcd3f291a,
+        type: 3}
+      propertyPath: m_Layer
+      value: 10
+      objectReference: {fileID: 0}
+    - target: {fileID: 9106589525454402192, guid: 328a1197c4ce3a34db1c0dffcd3f291a,
+        type: 3}
+      propertyPath: m_Layer
+      value: 10
+      objectReference: {fileID: 0}
+    - target: {fileID: 9144958313241242004, guid: 328a1197c4ce3a34db1c0dffcd3f291a,
+        type: 3}
+      propertyPath: m_Layer
+      value: 10
+      objectReference: {fileID: 0}
+    - target: {fileID: 9180950881526038679, guid: 328a1197c4ce3a34db1c0dffcd3f291a,
+        type: 3}
+      propertyPath: m_Layer
+      value: 10
+      objectReference: {fileID: 0}
+    - target: {fileID: 9186608878304633974, guid: 328a1197c4ce3a34db1c0dffcd3f291a,
+        type: 3}
+      propertyPath: m_Layer
+      value: 10
+      objectReference: {fileID: 0}
+    - target: {fileID: 9215471172276939686, guid: 328a1197c4ce3a34db1c0dffcd3f291a,
+        type: 3}
+      propertyPath: m_Layer
+      value: 10
       objectReference: {fileID: 0}
     m_RemovedComponents: []
     m_RemovedGameObjects: []

--- a/Assets/Characters/Players/Graber.prefab
+++ b/Assets/Characters/Players/Graber.prefab
@@ -9,7 +9,7 @@ GameObject:
   serializedVersion: 6
   m_Component:
   - component: {fileID: 4908638487692324497}
-  m_Layer: 0
+  m_Layer: 10
   m_Name: ItemDropPoint
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -228,10 +228,155 @@ PrefabInstance:
     serializedVersion: 3
     m_TransformParent: {fileID: 196070535118912173}
     m_Modifications:
+    - target: {fileID: 61888440002284650, guid: 850fe302612420b47b5841900d23f09a,
+        type: 3}
+      propertyPath: m_Layer
+      value: 10
+      objectReference: {fileID: 0}
+    - target: {fileID: 440470179219527025, guid: 850fe302612420b47b5841900d23f09a,
+        type: 3}
+      propertyPath: m_Layer
+      value: 10
+      objectReference: {fileID: 0}
+    - target: {fileID: 449216587648157748, guid: 850fe302612420b47b5841900d23f09a,
+        type: 3}
+      propertyPath: m_Layer
+      value: 10
+      objectReference: {fileID: 0}
+    - target: {fileID: 674631779490151661, guid: 850fe302612420b47b5841900d23f09a,
+        type: 3}
+      propertyPath: m_Layer
+      value: 10
+      objectReference: {fileID: 0}
+    - target: {fileID: 754708910135282159, guid: 850fe302612420b47b5841900d23f09a,
+        type: 3}
+      propertyPath: m_Layer
+      value: 10
+      objectReference: {fileID: 0}
+    - target: {fileID: 780032327323927485, guid: 850fe302612420b47b5841900d23f09a,
+        type: 3}
+      propertyPath: m_Layer
+      value: 10
+      objectReference: {fileID: 0}
+    - target: {fileID: 963926468283078122, guid: 850fe302612420b47b5841900d23f09a,
+        type: 3}
+      propertyPath: m_Layer
+      value: 10
+      objectReference: {fileID: 0}
+    - target: {fileID: 1015855871500144800, guid: 850fe302612420b47b5841900d23f09a,
+        type: 3}
+      propertyPath: m_Layer
+      value: 10
+      objectReference: {fileID: 0}
+    - target: {fileID: 1122966869092835190, guid: 850fe302612420b47b5841900d23f09a,
+        type: 3}
+      propertyPath: m_Layer
+      value: 10
+      objectReference: {fileID: 0}
+    - target: {fileID: 1140782467958465976, guid: 850fe302612420b47b5841900d23f09a,
+        type: 3}
+      propertyPath: m_Layer
+      value: 10
+      objectReference: {fileID: 0}
+    - target: {fileID: 1192154193322708222, guid: 850fe302612420b47b5841900d23f09a,
+        type: 3}
+      propertyPath: m_Layer
+      value: 10
+      objectReference: {fileID: 0}
+    - target: {fileID: 1199903696826367393, guid: 850fe302612420b47b5841900d23f09a,
+        type: 3}
+      propertyPath: m_Layer
+      value: 10
+      objectReference: {fileID: 0}
+    - target: {fileID: 1255291592203161681, guid: 850fe302612420b47b5841900d23f09a,
+        type: 3}
+      propertyPath: m_Layer
+      value: 10
+      objectReference: {fileID: 0}
+    - target: {fileID: 1302110261048684295, guid: 850fe302612420b47b5841900d23f09a,
+        type: 3}
+      propertyPath: m_Layer
+      value: 10
+      objectReference: {fileID: 0}
     - target: {fileID: 1361474361254401969, guid: 850fe302612420b47b5841900d23f09a,
         type: 3}
       propertyPath: m_IsActive
       value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1412869752632458937, guid: 850fe302612420b47b5841900d23f09a,
+        type: 3}
+      propertyPath: m_Layer
+      value: 10
+      objectReference: {fileID: 0}
+    - target: {fileID: 1483668580164223086, guid: 850fe302612420b47b5841900d23f09a,
+        type: 3}
+      propertyPath: m_Layer
+      value: 10
+      objectReference: {fileID: 0}
+    - target: {fileID: 1542576519352239002, guid: 850fe302612420b47b5841900d23f09a,
+        type: 3}
+      propertyPath: m_Layer
+      value: 10
+      objectReference: {fileID: 0}
+    - target: {fileID: 1618105994745275511, guid: 850fe302612420b47b5841900d23f09a,
+        type: 3}
+      propertyPath: m_Layer
+      value: 10
+      objectReference: {fileID: 0}
+    - target: {fileID: 1651168475745332135, guid: 850fe302612420b47b5841900d23f09a,
+        type: 3}
+      propertyPath: m_Layer
+      value: 10
+      objectReference: {fileID: 0}
+    - target: {fileID: 1656777998452969286, guid: 850fe302612420b47b5841900d23f09a,
+        type: 3}
+      propertyPath: m_Layer
+      value: 10
+      objectReference: {fileID: 0}
+    - target: {fileID: 1692843022870144581, guid: 850fe302612420b47b5841900d23f09a,
+        type: 3}
+      propertyPath: m_Layer
+      value: 10
+      objectReference: {fileID: 0}
+    - target: {fileID: 1726670914534456641, guid: 850fe302612420b47b5841900d23f09a,
+        type: 3}
+      propertyPath: m_Layer
+      value: 10
+      objectReference: {fileID: 0}
+    - target: {fileID: 1734728751324237254, guid: 850fe302612420b47b5841900d23f09a,
+        type: 3}
+      propertyPath: m_Layer
+      value: 10
+      objectReference: {fileID: 0}
+    - target: {fileID: 1818927683471306798, guid: 850fe302612420b47b5841900d23f09a,
+        type: 3}
+      propertyPath: m_Layer
+      value: 10
+      objectReference: {fileID: 0}
+    - target: {fileID: 1840435273634097124, guid: 850fe302612420b47b5841900d23f09a,
+        type: 3}
+      propertyPath: m_Layer
+      value: 10
+      objectReference: {fileID: 0}
+    - target: {fileID: 1932394525013595020, guid: 850fe302612420b47b5841900d23f09a,
+        type: 3}
+      propertyPath: m_Layer
+      value: 10
+      objectReference: {fileID: 0}
+    - target: {fileID: 2188766356489641305, guid: 850fe302612420b47b5841900d23f09a,
+        type: 3}
+      propertyPath: m_Layer
+      value: 10
+      objectReference: {fileID: 0}
+    - target: {fileID: 2222872644632431567, guid: 850fe302612420b47b5841900d23f09a,
+        type: 3}
+      propertyPath: m_Layer
+      value: 10
+      objectReference: {fileID: 0}
+    - target: {fileID: 2223607154606265990, guid: 850fe302612420b47b5841900d23f09a,
+        type: 3}
+      propertyPath: m_Layer
+      value: 10
       objectReference: {fileID: 0}
     - target: {fileID: 2298845404842334886, guid: 850fe302612420b47b5841900d23f09a,
         type: 3}
@@ -248,20 +393,215 @@ PrefabInstance:
       propertyPath: m_LocalPosition.z
       value: -0.068
       objectReference: {fileID: 0}
+    - target: {fileID: 2383488794140797388, guid: 850fe302612420b47b5841900d23f09a,
+        type: 3}
+      propertyPath: m_Layer
+      value: 10
+      objectReference: {fileID: 0}
+    - target: {fileID: 2559564101892727053, guid: 850fe302612420b47b5841900d23f09a,
+        type: 3}
+      propertyPath: m_Layer
+      value: 10
+      objectReference: {fileID: 0}
     - target: {fileID: 2769326546111968366, guid: 850fe302612420b47b5841900d23f09a,
         type: 3}
       propertyPath: m_IsActive
       value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2790445444831370248, guid: 850fe302612420b47b5841900d23f09a,
+        type: 3}
+      propertyPath: m_Layer
+      value: 10
+      objectReference: {fileID: 0}
+    - target: {fileID: 2908034897802261320, guid: 850fe302612420b47b5841900d23f09a,
+        type: 3}
+      propertyPath: m_Layer
+      value: 10
+      objectReference: {fileID: 0}
+    - target: {fileID: 3141851708957685294, guid: 850fe302612420b47b5841900d23f09a,
+        type: 3}
+      propertyPath: m_Layer
+      value: 10
+      objectReference: {fileID: 0}
+    - target: {fileID: 3295662753835801418, guid: 850fe302612420b47b5841900d23f09a,
+        type: 3}
+      propertyPath: m_Layer
+      value: 10
+      objectReference: {fileID: 0}
+    - target: {fileID: 3446910341810842927, guid: 850fe302612420b47b5841900d23f09a,
+        type: 3}
+      propertyPath: m_Layer
+      value: 10
+      objectReference: {fileID: 0}
+    - target: {fileID: 3494102562636474850, guid: 850fe302612420b47b5841900d23f09a,
+        type: 3}
+      propertyPath: m_Layer
+      value: 10
+      objectReference: {fileID: 0}
+    - target: {fileID: 3626992682045669999, guid: 850fe302612420b47b5841900d23f09a,
+        type: 3}
+      propertyPath: m_Layer
+      value: 10
+      objectReference: {fileID: 0}
+    - target: {fileID: 3708453715631415480, guid: 850fe302612420b47b5841900d23f09a,
+        type: 3}
+      propertyPath: m_Layer
+      value: 10
+      objectReference: {fileID: 0}
+    - target: {fileID: 3808993972003707764, guid: 850fe302612420b47b5841900d23f09a,
+        type: 3}
+      propertyPath: m_Layer
+      value: 10
+      objectReference: {fileID: 0}
+    - target: {fileID: 3934628109002879839, guid: 850fe302612420b47b5841900d23f09a,
+        type: 3}
+      propertyPath: m_Layer
+      value: 10
+      objectReference: {fileID: 0}
+    - target: {fileID: 4129101897375001532, guid: 850fe302612420b47b5841900d23f09a,
+        type: 3}
+      propertyPath: m_Layer
+      value: 10
+      objectReference: {fileID: 0}
+    - target: {fileID: 4233266988207691275, guid: 850fe302612420b47b5841900d23f09a,
+        type: 3}
+      propertyPath: m_Layer
+      value: 10
+      objectReference: {fileID: 0}
+    - target: {fileID: 4266161125997469289, guid: 850fe302612420b47b5841900d23f09a,
+        type: 3}
+      propertyPath: m_Layer
+      value: 10
+      objectReference: {fileID: 0}
+    - target: {fileID: 4636206180440983701, guid: 850fe302612420b47b5841900d23f09a,
+        type: 3}
+      propertyPath: m_Layer
+      value: 10
+      objectReference: {fileID: 0}
+    - target: {fileID: 4710287356788998569, guid: 850fe302612420b47b5841900d23f09a,
+        type: 3}
+      propertyPath: m_Layer
+      value: 10
       objectReference: {fileID: 0}
     - target: {fileID: 4713012211943290316, guid: 850fe302612420b47b5841900d23f09a,
         type: 3}
       propertyPath: m_Name
       value: graberPreview
       objectReference: {fileID: 0}
+    - target: {fileID: 4713012211943290316, guid: 850fe302612420b47b5841900d23f09a,
+        type: 3}
+      propertyPath: m_Layer
+      value: 10
+      objectReference: {fileID: 0}
+    - target: {fileID: 4773004450879149397, guid: 850fe302612420b47b5841900d23f09a,
+        type: 3}
+      propertyPath: m_Layer
+      value: 10
+      objectReference: {fileID: 0}
+    - target: {fileID: 5055938735024749975, guid: 850fe302612420b47b5841900d23f09a,
+        type: 3}
+      propertyPath: m_Layer
+      value: 10
+      objectReference: {fileID: 0}
+    - target: {fileID: 5109267618302521508, guid: 850fe302612420b47b5841900d23f09a,
+        type: 3}
+      propertyPath: m_Layer
+      value: 10
+      objectReference: {fileID: 0}
+    - target: {fileID: 5150298941775622752, guid: 850fe302612420b47b5841900d23f09a,
+        type: 3}
+      propertyPath: m_Layer
+      value: 10
+      objectReference: {fileID: 0}
+    - target: {fileID: 5411018462219312729, guid: 850fe302612420b47b5841900d23f09a,
+        type: 3}
+      propertyPath: m_Layer
+      value: 10
+      objectReference: {fileID: 0}
+    - target: {fileID: 5423352950238333608, guid: 850fe302612420b47b5841900d23f09a,
+        type: 3}
+      propertyPath: m_Layer
+      value: 10
+      objectReference: {fileID: 0}
+    - target: {fileID: 5714253070399399454, guid: 850fe302612420b47b5841900d23f09a,
+        type: 3}
+      propertyPath: m_Layer
+      value: 10
+      objectReference: {fileID: 0}
+    - target: {fileID: 5982533431927765850, guid: 850fe302612420b47b5841900d23f09a,
+        type: 3}
+      propertyPath: m_Layer
+      value: 10
+      objectReference: {fileID: 0}
+    - target: {fileID: 6024202907578044026, guid: 850fe302612420b47b5841900d23f09a,
+        type: 3}
+      propertyPath: m_Layer
+      value: 10
+      objectReference: {fileID: 0}
+    - target: {fileID: 6195654350416235142, guid: 850fe302612420b47b5841900d23f09a,
+        type: 3}
+      propertyPath: m_Layer
+      value: 10
+      objectReference: {fileID: 0}
+    - target: {fileID: 6466957538846328309, guid: 850fe302612420b47b5841900d23f09a,
+        type: 3}
+      propertyPath: m_Layer
+      value: 10
+      objectReference: {fileID: 0}
+    - target: {fileID: 6641644786103534669, guid: 850fe302612420b47b5841900d23f09a,
+        type: 3}
+      propertyPath: m_Layer
+      value: 10
+      objectReference: {fileID: 0}
+    - target: {fileID: 6694303724187636587, guid: 850fe302612420b47b5841900d23f09a,
+        type: 3}
+      propertyPath: m_Layer
+      value: 10
+      objectReference: {fileID: 0}
+    - target: {fileID: 6833536846111217724, guid: 850fe302612420b47b5841900d23f09a,
+        type: 3}
+      propertyPath: m_Layer
+      value: 10
+      objectReference: {fileID: 0}
+    - target: {fileID: 7122220622362899795, guid: 850fe302612420b47b5841900d23f09a,
+        type: 3}
+      propertyPath: m_Layer
+      value: 10
+      objectReference: {fileID: 0}
+    - target: {fileID: 7173527646900975178, guid: 850fe302612420b47b5841900d23f09a,
+        type: 3}
+      propertyPath: m_Layer
+      value: 10
+      objectReference: {fileID: 0}
     - target: {fileID: 7227208214214287409, guid: 850fe302612420b47b5841900d23f09a,
         type: 3}
       propertyPath: m_IsActive
       value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7484660364033806886, guid: 850fe302612420b47b5841900d23f09a,
+        type: 3}
+      propertyPath: m_Layer
+      value: 10
+      objectReference: {fileID: 0}
+    - target: {fileID: 7612513534345831122, guid: 850fe302612420b47b5841900d23f09a,
+        type: 3}
+      propertyPath: m_Layer
+      value: 10
+      objectReference: {fileID: 0}
+    - target: {fileID: 7804621534080364899, guid: 850fe302612420b47b5841900d23f09a,
+        type: 3}
+      propertyPath: m_Layer
+      value: 10
+      objectReference: {fileID: 0}
+    - target: {fileID: 7806703932620005580, guid: 850fe302612420b47b5841900d23f09a,
+        type: 3}
+      propertyPath: m_Layer
+      value: 10
+      objectReference: {fileID: 0}
+    - target: {fileID: 7910466930511636331, guid: 850fe302612420b47b5841900d23f09a,
+        type: 3}
+      propertyPath: m_Layer
+      value: 10
       objectReference: {fileID: 0}
     - target: {fileID: 8000613096139225739, guid: 850fe302612420b47b5841900d23f09a,
         type: 3}
@@ -277,6 +617,31 @@ PrefabInstance:
         type: 3}
       propertyPath: m_LocalPosition.z
       value: -0.012
+      objectReference: {fileID: 0}
+    - target: {fileID: 8017063083897728630, guid: 850fe302612420b47b5841900d23f09a,
+        type: 3}
+      propertyPath: m_Layer
+      value: 10
+      objectReference: {fileID: 0}
+    - target: {fileID: 8234901589412684787, guid: 850fe302612420b47b5841900d23f09a,
+        type: 3}
+      propertyPath: m_Layer
+      value: 10
+      objectReference: {fileID: 0}
+    - target: {fileID: 8280081695626522554, guid: 850fe302612420b47b5841900d23f09a,
+        type: 3}
+      propertyPath: m_Layer
+      value: 10
+      objectReference: {fileID: 0}
+    - target: {fileID: 8343520002913363070, guid: 850fe302612420b47b5841900d23f09a,
+        type: 3}
+      propertyPath: m_Layer
+      value: 10
+      objectReference: {fileID: 0}
+    - target: {fileID: 8464873088512124229, guid: 850fe302612420b47b5841900d23f09a,
+        type: 3}
+      propertyPath: m_Layer
+      value: 10
       objectReference: {fileID: 0}
     - target: {fileID: 8591920834881505247, guid: 850fe302612420b47b5841900d23f09a,
         type: 3}
@@ -327,6 +692,21 @@ PrefabInstance:
         type: 3}
       propertyPath: m_LocalEulerAnglesHint.z
       value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8689753713568575575, guid: 850fe302612420b47b5841900d23f09a,
+        type: 3}
+      propertyPath: m_Layer
+      value: 10
+      objectReference: {fileID: 0}
+    - target: {fileID: 8926062094723994623, guid: 850fe302612420b47b5841900d23f09a,
+        type: 3}
+      propertyPath: m_Layer
+      value: 10
+      objectReference: {fileID: 0}
+    - target: {fileID: 9021473220792254511, guid: 850fe302612420b47b5841900d23f09a,
+        type: 3}
+      propertyPath: m_Layer
+      value: 10
       objectReference: {fileID: 0}
     m_RemovedComponents: []
     m_RemovedGameObjects: []

--- a/Assets/Characters/Players/Poly.prefab
+++ b/Assets/Characters/Players/Poly.prefab
@@ -9,7 +9,7 @@ GameObject:
   serializedVersion: 6
   m_Component:
   - component: {fileID: 3383645509301822644}
-  m_Layer: 0
+  m_Layer: 10
   m_Name: ItemDropPoint
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -39,6 +39,71 @@ PrefabInstance:
     serializedVersion: 3
     m_TransformParent: {fileID: 8772761477247295530}
     m_Modifications:
+    - target: {fileID: 75269746996166098, guid: cda20b932e8cfde47b627abf798dcc58,
+        type: 3}
+      propertyPath: m_Layer
+      value: 10
+      objectReference: {fileID: 0}
+    - target: {fileID: 239555828103728421, guid: cda20b932e8cfde47b627abf798dcc58,
+        type: 3}
+      propertyPath: m_Layer
+      value: 10
+      objectReference: {fileID: 0}
+    - target: {fileID: 415523843035948198, guid: cda20b932e8cfde47b627abf798dcc58,
+        type: 3}
+      propertyPath: m_Layer
+      value: 10
+      objectReference: {fileID: 0}
+    - target: {fileID: 465300940196940742, guid: cda20b932e8cfde47b627abf798dcc58,
+        type: 3}
+      propertyPath: m_Layer
+      value: 10
+      objectReference: {fileID: 0}
+    - target: {fileID: 689506835331629580, guid: cda20b932e8cfde47b627abf798dcc58,
+        type: 3}
+      propertyPath: m_Layer
+      value: 10
+      objectReference: {fileID: 0}
+    - target: {fileID: 865095626639846983, guid: cda20b932e8cfde47b627abf798dcc58,
+        type: 3}
+      propertyPath: m_Layer
+      value: 10
+      objectReference: {fileID: 0}
+    - target: {fileID: 968229400996673304, guid: cda20b932e8cfde47b627abf798dcc58,
+        type: 3}
+      propertyPath: m_Layer
+      value: 10
+      objectReference: {fileID: 0}
+    - target: {fileID: 1123232719861755004, guid: cda20b932e8cfde47b627abf798dcc58,
+        type: 3}
+      propertyPath: m_Layer
+      value: 10
+      objectReference: {fileID: 0}
+    - target: {fileID: 1204369484943771385, guid: cda20b932e8cfde47b627abf798dcc58,
+        type: 3}
+      propertyPath: m_Layer
+      value: 10
+      objectReference: {fileID: 0}
+    - target: {fileID: 1274776289464514157, guid: cda20b932e8cfde47b627abf798dcc58,
+        type: 3}
+      propertyPath: m_Layer
+      value: 10
+      objectReference: {fileID: 0}
+    - target: {fileID: 1463602480219435723, guid: cda20b932e8cfde47b627abf798dcc58,
+        type: 3}
+      propertyPath: m_Layer
+      value: 10
+      objectReference: {fileID: 0}
+    - target: {fileID: 1728975086518887441, guid: cda20b932e8cfde47b627abf798dcc58,
+        type: 3}
+      propertyPath: m_Layer
+      value: 10
+      objectReference: {fileID: 0}
+    - target: {fileID: 1779859693745197782, guid: cda20b932e8cfde47b627abf798dcc58,
+        type: 3}
+      propertyPath: m_Layer
+      value: 10
+      objectReference: {fileID: 0}
     - target: {fileID: 2093991230673338252, guid: cda20b932e8cfde47b627abf798dcc58,
         type: 3}
       propertyPath: m_LocalPosition.x
@@ -54,10 +119,125 @@ PrefabInstance:
       propertyPath: m_LocalPosition.z
       value: -0.052
       objectReference: {fileID: 0}
+    - target: {fileID: 2274165702744651866, guid: cda20b932e8cfde47b627abf798dcc58,
+        type: 3}
+      propertyPath: m_Layer
+      value: 10
+      objectReference: {fileID: 0}
+    - target: {fileID: 2433361880973464622, guid: cda20b932e8cfde47b627abf798dcc58,
+        type: 3}
+      propertyPath: m_Layer
+      value: 10
+      objectReference: {fileID: 0}
     - target: {fileID: 2632043419390415172, guid: cda20b932e8cfde47b627abf798dcc58,
         type: 3}
       propertyPath: m_IsActive
       value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2658282897010898234, guid: cda20b932e8cfde47b627abf798dcc58,
+        type: 3}
+      propertyPath: m_Layer
+      value: 10
+      objectReference: {fileID: 0}
+    - target: {fileID: 2707528632837149694, guid: cda20b932e8cfde47b627abf798dcc58,
+        type: 3}
+      propertyPath: m_Layer
+      value: 10
+      objectReference: {fileID: 0}
+    - target: {fileID: 2972090783051847031, guid: cda20b932e8cfde47b627abf798dcc58,
+        type: 3}
+      propertyPath: m_Layer
+      value: 10
+      objectReference: {fileID: 0}
+    - target: {fileID: 2998043423976138085, guid: cda20b932e8cfde47b627abf798dcc58,
+        type: 3}
+      propertyPath: m_Layer
+      value: 10
+      objectReference: {fileID: 0}
+    - target: {fileID: 3062242245392877427, guid: cda20b932e8cfde47b627abf798dcc58,
+        type: 3}
+      propertyPath: m_Layer
+      value: 10
+      objectReference: {fileID: 0}
+    - target: {fileID: 3064770520749922523, guid: cda20b932e8cfde47b627abf798dcc58,
+        type: 3}
+      propertyPath: m_Layer
+      value: 10
+      objectReference: {fileID: 0}
+    - target: {fileID: 3220870968787289451, guid: cda20b932e8cfde47b627abf798dcc58,
+        type: 3}
+      propertyPath: m_Layer
+      value: 10
+      objectReference: {fileID: 0}
+    - target: {fileID: 3279175422554488249, guid: cda20b932e8cfde47b627abf798dcc58,
+        type: 3}
+      propertyPath: m_Layer
+      value: 10
+      objectReference: {fileID: 0}
+    - target: {fileID: 3378501793430028048, guid: cda20b932e8cfde47b627abf798dcc58,
+        type: 3}
+      propertyPath: m_Layer
+      value: 10
+      objectReference: {fileID: 0}
+    - target: {fileID: 3717978089860633874, guid: cda20b932e8cfde47b627abf798dcc58,
+        type: 3}
+      propertyPath: m_Layer
+      value: 10
+      objectReference: {fileID: 0}
+    - target: {fileID: 3982997587771938825, guid: cda20b932e8cfde47b627abf798dcc58,
+        type: 3}
+      propertyPath: m_Layer
+      value: 10
+      objectReference: {fileID: 0}
+    - target: {fileID: 4074406636763129113, guid: cda20b932e8cfde47b627abf798dcc58,
+        type: 3}
+      propertyPath: m_Layer
+      value: 10
+      objectReference: {fileID: 0}
+    - target: {fileID: 4117213017015856997, guid: cda20b932e8cfde47b627abf798dcc58,
+        type: 3}
+      propertyPath: m_Layer
+      value: 10
+      objectReference: {fileID: 0}
+    - target: {fileID: 4217543097919323573, guid: cda20b932e8cfde47b627abf798dcc58,
+        type: 3}
+      propertyPath: m_Layer
+      value: 10
+      objectReference: {fileID: 0}
+    - target: {fileID: 4333667481154671398, guid: cda20b932e8cfde47b627abf798dcc58,
+        type: 3}
+      propertyPath: m_Layer
+      value: 10
+      objectReference: {fileID: 0}
+    - target: {fileID: 4509983023516306974, guid: cda20b932e8cfde47b627abf798dcc58,
+        type: 3}
+      propertyPath: m_Layer
+      value: 10
+      objectReference: {fileID: 0}
+    - target: {fileID: 4591488932892203684, guid: cda20b932e8cfde47b627abf798dcc58,
+        type: 3}
+      propertyPath: m_Layer
+      value: 10
+      objectReference: {fileID: 0}
+    - target: {fileID: 4611556296197192861, guid: cda20b932e8cfde47b627abf798dcc58,
+        type: 3}
+      propertyPath: m_Layer
+      value: 10
+      objectReference: {fileID: 0}
+    - target: {fileID: 4668940981064897244, guid: cda20b932e8cfde47b627abf798dcc58,
+        type: 3}
+      propertyPath: m_Layer
+      value: 10
+      objectReference: {fileID: 0}
+    - target: {fileID: 4793521073515534052, guid: cda20b932e8cfde47b627abf798dcc58,
+        type: 3}
+      propertyPath: m_Layer
+      value: 10
+      objectReference: {fileID: 0}
+    - target: {fileID: 4824725739270282851, guid: cda20b932e8cfde47b627abf798dcc58,
+        type: 3}
+      propertyPath: m_Layer
+      value: 10
       objectReference: {fileID: 0}
     - target: {fileID: 4998698800173758321, guid: cda20b932e8cfde47b627abf798dcc58,
         type: 3}
@@ -109,15 +289,210 @@ PrefabInstance:
       propertyPath: m_LocalEulerAnglesHint.z
       value: 0
       objectReference: {fileID: 0}
+    - target: {fileID: 5146337625005750458, guid: cda20b932e8cfde47b627abf798dcc58,
+        type: 3}
+      propertyPath: m_Layer
+      value: 10
+      objectReference: {fileID: 0}
+    - target: {fileID: 5333845619686585586, guid: cda20b932e8cfde47b627abf798dcc58,
+        type: 3}
+      propertyPath: m_Layer
+      value: 10
+      objectReference: {fileID: 0}
+    - target: {fileID: 5528772826364017135, guid: cda20b932e8cfde47b627abf798dcc58,
+        type: 3}
+      propertyPath: m_Layer
+      value: 10
+      objectReference: {fileID: 0}
+    - target: {fileID: 5607346517386366608, guid: cda20b932e8cfde47b627abf798dcc58,
+        type: 3}
+      propertyPath: m_Layer
+      value: 10
+      objectReference: {fileID: 0}
     - target: {fileID: 5626441515505511883, guid: cda20b932e8cfde47b627abf798dcc58,
         type: 3}
       propertyPath: m_Name
       value: PixelGirlPreview
       objectReference: {fileID: 0}
+    - target: {fileID: 5626441515505511883, guid: cda20b932e8cfde47b627abf798dcc58,
+        type: 3}
+      propertyPath: m_Layer
+      value: 10
+      objectReference: {fileID: 0}
+    - target: {fileID: 5782967346721793911, guid: cda20b932e8cfde47b627abf798dcc58,
+        type: 3}
+      propertyPath: m_Layer
+      value: 10
+      objectReference: {fileID: 0}
+    - target: {fileID: 5922440110065253806, guid: cda20b932e8cfde47b627abf798dcc58,
+        type: 3}
+      propertyPath: m_Layer
+      value: 10
+      objectReference: {fileID: 0}
+    - target: {fileID: 6130586039228801041, guid: cda20b932e8cfde47b627abf798dcc58,
+        type: 3}
+      propertyPath: m_Layer
+      value: 10
+      objectReference: {fileID: 0}
+    - target: {fileID: 6299731588337548321, guid: cda20b932e8cfde47b627abf798dcc58,
+        type: 3}
+      propertyPath: m_Layer
+      value: 10
+      objectReference: {fileID: 0}
+    - target: {fileID: 6560922633889714933, guid: cda20b932e8cfde47b627abf798dcc58,
+        type: 3}
+      propertyPath: m_Layer
+      value: 10
+      objectReference: {fileID: 0}
+    - target: {fileID: 6855167398223735214, guid: cda20b932e8cfde47b627abf798dcc58,
+        type: 3}
+      propertyPath: m_Layer
+      value: 10
+      objectReference: {fileID: 0}
+    - target: {fileID: 6917018266604635843, guid: cda20b932e8cfde47b627abf798dcc58,
+        type: 3}
+      propertyPath: m_Layer
+      value: 10
+      objectReference: {fileID: 0}
+    - target: {fileID: 7005285708973235044, guid: cda20b932e8cfde47b627abf798dcc58,
+        type: 3}
+      propertyPath: m_Layer
+      value: 10
+      objectReference: {fileID: 0}
+    - target: {fileID: 7054181951001596476, guid: cda20b932e8cfde47b627abf798dcc58,
+        type: 3}
+      propertyPath: m_Layer
+      value: 10
+      objectReference: {fileID: 0}
+    - target: {fileID: 7111674294951815831, guid: cda20b932e8cfde47b627abf798dcc58,
+        type: 3}
+      propertyPath: m_Layer
+      value: 10
+      objectReference: {fileID: 0}
+    - target: {fileID: 7251000678071836018, guid: cda20b932e8cfde47b627abf798dcc58,
+        type: 3}
+      propertyPath: m_Layer
+      value: 10
+      objectReference: {fileID: 0}
+    - target: {fileID: 7299387425943474839, guid: cda20b932e8cfde47b627abf798dcc58,
+        type: 3}
+      propertyPath: m_Layer
+      value: 10
+      objectReference: {fileID: 0}
     - target: {fileID: 7396117633272939803, guid: cda20b932e8cfde47b627abf798dcc58,
         type: 3}
       propertyPath: m_IsActive
       value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7407950812521727555, guid: cda20b932e8cfde47b627abf798dcc58,
+        type: 3}
+      propertyPath: m_Layer
+      value: 10
+      objectReference: {fileID: 0}
+    - target: {fileID: 7456811098332495259, guid: cda20b932e8cfde47b627abf798dcc58,
+        type: 3}
+      propertyPath: m_Layer
+      value: 10
+      objectReference: {fileID: 0}
+    - target: {fileID: 7532765529836278426, guid: cda20b932e8cfde47b627abf798dcc58,
+        type: 3}
+      propertyPath: m_Layer
+      value: 10
+      objectReference: {fileID: 0}
+    - target: {fileID: 7538581088085468520, guid: cda20b932e8cfde47b627abf798dcc58,
+        type: 3}
+      propertyPath: m_Layer
+      value: 10
+      objectReference: {fileID: 0}
+    - target: {fileID: 7576915848038547422, guid: cda20b932e8cfde47b627abf798dcc58,
+        type: 3}
+      propertyPath: m_Layer
+      value: 10
+      objectReference: {fileID: 0}
+    - target: {fileID: 7588931032920513207, guid: cda20b932e8cfde47b627abf798dcc58,
+        type: 3}
+      propertyPath: m_Layer
+      value: 10
+      objectReference: {fileID: 0}
+    - target: {fileID: 7704900056711996766, guid: cda20b932e8cfde47b627abf798dcc58,
+        type: 3}
+      propertyPath: m_Layer
+      value: 10
+      objectReference: {fileID: 0}
+    - target: {fileID: 7759142858424867395, guid: cda20b932e8cfde47b627abf798dcc58,
+        type: 3}
+      propertyPath: m_Layer
+      value: 10
+      objectReference: {fileID: 0}
+    - target: {fileID: 7809537322436998428, guid: cda20b932e8cfde47b627abf798dcc58,
+        type: 3}
+      propertyPath: m_Layer
+      value: 10
+      objectReference: {fileID: 0}
+    - target: {fileID: 8071906535013986317, guid: cda20b932e8cfde47b627abf798dcc58,
+        type: 3}
+      propertyPath: m_Layer
+      value: 10
+      objectReference: {fileID: 0}
+    - target: {fileID: 8141831381977326227, guid: cda20b932e8cfde47b627abf798dcc58,
+        type: 3}
+      propertyPath: m_Layer
+      value: 10
+      objectReference: {fileID: 0}
+    - target: {fileID: 8294061267722363522, guid: cda20b932e8cfde47b627abf798dcc58,
+        type: 3}
+      propertyPath: m_Layer
+      value: 10
+      objectReference: {fileID: 0}
+    - target: {fileID: 8365760335938586065, guid: cda20b932e8cfde47b627abf798dcc58,
+        type: 3}
+      propertyPath: m_Layer
+      value: 10
+      objectReference: {fileID: 0}
+    - target: {fileID: 8445148695769277922, guid: cda20b932e8cfde47b627abf798dcc58,
+        type: 3}
+      propertyPath: m_Layer
+      value: 10
+      objectReference: {fileID: 0}
+    - target: {fileID: 8499067066048883590, guid: cda20b932e8cfde47b627abf798dcc58,
+        type: 3}
+      propertyPath: m_Layer
+      value: 10
+      objectReference: {fileID: 0}
+    - target: {fileID: 8590278259851652009, guid: cda20b932e8cfde47b627abf798dcc58,
+        type: 3}
+      propertyPath: m_Layer
+      value: 10
+      objectReference: {fileID: 0}
+    - target: {fileID: 8654117230878429747, guid: cda20b932e8cfde47b627abf798dcc58,
+        type: 3}
+      propertyPath: m_Layer
+      value: 10
+      objectReference: {fileID: 0}
+    - target: {fileID: 8668268929526086352, guid: cda20b932e8cfde47b627abf798dcc58,
+        type: 3}
+      propertyPath: m_Layer
+      value: 10
+      objectReference: {fileID: 0}
+    - target: {fileID: 8918167822669069739, guid: cda20b932e8cfde47b627abf798dcc58,
+        type: 3}
+      propertyPath: m_Layer
+      value: 10
+      objectReference: {fileID: 0}
+    - target: {fileID: 8986100020520474966, guid: cda20b932e8cfde47b627abf798dcc58,
+        type: 3}
+      propertyPath: m_Layer
+      value: 10
+      objectReference: {fileID: 0}
+    - target: {fileID: 9076435818772008775, guid: cda20b932e8cfde47b627abf798dcc58,
+        type: 3}
+      propertyPath: m_Layer
+      value: 10
+      objectReference: {fileID: 0}
+    - target: {fileID: 9183075959919469111, guid: cda20b932e8cfde47b627abf798dcc58,
+        type: 3}
+      propertyPath: m_Layer
+      value: 10
       objectReference: {fileID: 0}
     m_RemovedComponents: []
     m_RemovedGameObjects: []

--- a/Assets/Characters/Players/Sergey.prefab
+++ b/Assets/Characters/Players/Sergey.prefab
@@ -9,7 +9,7 @@ GameObject:
   serializedVersion: 6
   m_Component:
   - component: {fileID: 8389219452962443152}
-  m_Layer: 0
+  m_Layer: 10
   m_Name: ItemDropPoint
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -228,6 +228,131 @@ PrefabInstance:
     serializedVersion: 3
     m_TransformParent: {fileID: 5852190505948574839}
     m_Modifications:
+    - target: {fileID: 131633651670673503, guid: 30bf4819dee88a0419769314b01e528d,
+        type: 3}
+      propertyPath: m_Layer
+      value: 10
+      objectReference: {fileID: 0}
+    - target: {fileID: 153049371400783437, guid: 30bf4819dee88a0419769314b01e528d,
+        type: 3}
+      propertyPath: m_Layer
+      value: 10
+      objectReference: {fileID: 0}
+    - target: {fileID: 594548290510451666, guid: 30bf4819dee88a0419769314b01e528d,
+        type: 3}
+      propertyPath: m_Layer
+      value: 10
+      objectReference: {fileID: 0}
+    - target: {fileID: 643625864893044232, guid: 30bf4819dee88a0419769314b01e528d,
+        type: 3}
+      propertyPath: m_Layer
+      value: 10
+      objectReference: {fileID: 0}
+    - target: {fileID: 657284142978716765, guid: 30bf4819dee88a0419769314b01e528d,
+        type: 3}
+      propertyPath: m_Layer
+      value: 10
+      objectReference: {fileID: 0}
+    - target: {fileID: 685984944862966918, guid: 30bf4819dee88a0419769314b01e528d,
+        type: 3}
+      propertyPath: m_Layer
+      value: 10
+      objectReference: {fileID: 0}
+    - target: {fileID: 797263569041634658, guid: 30bf4819dee88a0419769314b01e528d,
+        type: 3}
+      propertyPath: m_Layer
+      value: 10
+      objectReference: {fileID: 0}
+    - target: {fileID: 896686341902655286, guid: 30bf4819dee88a0419769314b01e528d,
+        type: 3}
+      propertyPath: m_Layer
+      value: 10
+      objectReference: {fileID: 0}
+    - target: {fileID: 1006234186355183605, guid: 30bf4819dee88a0419769314b01e528d,
+        type: 3}
+      propertyPath: m_Layer
+      value: 10
+      objectReference: {fileID: 0}
+    - target: {fileID: 1027410596675155312, guid: 30bf4819dee88a0419769314b01e528d,
+        type: 3}
+      propertyPath: m_Layer
+      value: 10
+      objectReference: {fileID: 0}
+    - target: {fileID: 1074700159520937724, guid: 30bf4819dee88a0419769314b01e528d,
+        type: 3}
+      propertyPath: m_Layer
+      value: 10
+      objectReference: {fileID: 0}
+    - target: {fileID: 1140892256741264810, guid: 30bf4819dee88a0419769314b01e528d,
+        type: 3}
+      propertyPath: m_Layer
+      value: 10
+      objectReference: {fileID: 0}
+    - target: {fileID: 1313256768917181560, guid: 30bf4819dee88a0419769314b01e528d,
+        type: 3}
+      propertyPath: m_Layer
+      value: 10
+      objectReference: {fileID: 0}
+    - target: {fileID: 1754984190615175402, guid: 30bf4819dee88a0419769314b01e528d,
+        type: 3}
+      propertyPath: m_Layer
+      value: 10
+      objectReference: {fileID: 0}
+    - target: {fileID: 1808788580878325398, guid: 30bf4819dee88a0419769314b01e528d,
+        type: 3}
+      propertyPath: m_Layer
+      value: 10
+      objectReference: {fileID: 0}
+    - target: {fileID: 1881709145021574984, guid: 30bf4819dee88a0419769314b01e528d,
+        type: 3}
+      propertyPath: m_Layer
+      value: 10
+      objectReference: {fileID: 0}
+    - target: {fileID: 2176275025719179150, guid: 30bf4819dee88a0419769314b01e528d,
+        type: 3}
+      propertyPath: m_Layer
+      value: 10
+      objectReference: {fileID: 0}
+    - target: {fileID: 2284894748502529798, guid: 30bf4819dee88a0419769314b01e528d,
+        type: 3}
+      propertyPath: m_Layer
+      value: 10
+      objectReference: {fileID: 0}
+    - target: {fileID: 2331463853686761579, guid: 30bf4819dee88a0419769314b01e528d,
+        type: 3}
+      propertyPath: m_Layer
+      value: 10
+      objectReference: {fileID: 0}
+    - target: {fileID: 2456672800639329447, guid: 30bf4819dee88a0419769314b01e528d,
+        type: 3}
+      propertyPath: m_Layer
+      value: 10
+      objectReference: {fileID: 0}
+    - target: {fileID: 2521319725185743796, guid: 30bf4819dee88a0419769314b01e528d,
+        type: 3}
+      propertyPath: m_Layer
+      value: 10
+      objectReference: {fileID: 0}
+    - target: {fileID: 2527625330084965440, guid: 30bf4819dee88a0419769314b01e528d,
+        type: 3}
+      propertyPath: m_Layer
+      value: 10
+      objectReference: {fileID: 0}
+    - target: {fileID: 2551416856549199888, guid: 30bf4819dee88a0419769314b01e528d,
+        type: 3}
+      propertyPath: m_Layer
+      value: 10
+      objectReference: {fileID: 0}
+    - target: {fileID: 2641624742614908579, guid: 30bf4819dee88a0419769314b01e528d,
+        type: 3}
+      propertyPath: m_Layer
+      value: 10
+      objectReference: {fileID: 0}
+    - target: {fileID: 2769335314997989109, guid: 30bf4819dee88a0419769314b01e528d,
+        type: 3}
+      propertyPath: m_Layer
+      value: 10
+      objectReference: {fileID: 0}
     - target: {fileID: 2770107307151243450, guid: 30bf4819dee88a0419769314b01e528d,
         type: 3}
       propertyPath: m_LocalPosition.x
@@ -243,10 +368,85 @@ PrefabInstance:
       propertyPath: m_LocalPosition.z
       value: -0.047
       objectReference: {fileID: 0}
+    - target: {fileID: 2886347684924511341, guid: 30bf4819dee88a0419769314b01e528d,
+        type: 3}
+      propertyPath: m_Layer
+      value: 10
+      objectReference: {fileID: 0}
+    - target: {fileID: 2911755568825598816, guid: 30bf4819dee88a0419769314b01e528d,
+        type: 3}
+      propertyPath: m_Layer
+      value: 10
+      objectReference: {fileID: 0}
+    - target: {fileID: 2944576121825062235, guid: 30bf4819dee88a0419769314b01e528d,
+        type: 3}
+      propertyPath: m_Layer
+      value: 10
+      objectReference: {fileID: 0}
     - target: {fileID: 3259116600305312256, guid: 30bf4819dee88a0419769314b01e528d,
         type: 3}
       propertyPath: m_IsActive
       value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3283983129772756332, guid: 30bf4819dee88a0419769314b01e528d,
+        type: 3}
+      propertyPath: m_Layer
+      value: 10
+      objectReference: {fileID: 0}
+    - target: {fileID: 3397802039435154819, guid: 30bf4819dee88a0419769314b01e528d,
+        type: 3}
+      propertyPath: m_Layer
+      value: 10
+      objectReference: {fileID: 0}
+    - target: {fileID: 3481994846089987197, guid: 30bf4819dee88a0419769314b01e528d,
+        type: 3}
+      propertyPath: m_Layer
+      value: 10
+      objectReference: {fileID: 0}
+    - target: {fileID: 3600641394542394635, guid: 30bf4819dee88a0419769314b01e528d,
+        type: 3}
+      propertyPath: m_Layer
+      value: 10
+      objectReference: {fileID: 0}
+    - target: {fileID: 3608652837559337731, guid: 30bf4819dee88a0419769314b01e528d,
+        type: 3}
+      propertyPath: m_Layer
+      value: 10
+      objectReference: {fileID: 0}
+    - target: {fileID: 3637256632471434706, guid: 30bf4819dee88a0419769314b01e528d,
+        type: 3}
+      propertyPath: m_Layer
+      value: 10
+      objectReference: {fileID: 0}
+    - target: {fileID: 3728153526317158070, guid: 30bf4819dee88a0419769314b01e528d,
+        type: 3}
+      propertyPath: m_Layer
+      value: 10
+      objectReference: {fileID: 0}
+    - target: {fileID: 3768121446896995511, guid: 30bf4819dee88a0419769314b01e528d,
+        type: 3}
+      propertyPath: m_Layer
+      value: 10
+      objectReference: {fileID: 0}
+    - target: {fileID: 3890602092740707719, guid: 30bf4819dee88a0419769314b01e528d,
+        type: 3}
+      propertyPath: m_Layer
+      value: 10
+      objectReference: {fileID: 0}
+    - target: {fileID: 3928284441571606071, guid: 30bf4819dee88a0419769314b01e528d,
+        type: 3}
+      propertyPath: m_Layer
+      value: 10
+      objectReference: {fileID: 0}
+    - target: {fileID: 3972229819763723449, guid: 30bf4819dee88a0419769314b01e528d,
+        type: 3}
+      propertyPath: m_Layer
+      value: 10
+      objectReference: {fileID: 0}
+    - target: {fileID: 4013062915335841759, guid: 30bf4819dee88a0419769314b01e528d,
+        type: 3}
+      propertyPath: m_Layer
+      value: 10
       objectReference: {fileID: 0}
     - target: {fileID: 4259186847290908103, guid: 30bf4819dee88a0419769314b01e528d,
         type: 3}
@@ -262,6 +462,86 @@ PrefabInstance:
         type: 3}
       propertyPath: m_LocalPosition.z
       value: -0.051
+      objectReference: {fileID: 0}
+    - target: {fileID: 4309510193435275695, guid: 30bf4819dee88a0419769314b01e528d,
+        type: 3}
+      propertyPath: m_Layer
+      value: 10
+      objectReference: {fileID: 0}
+    - target: {fileID: 4333631109791782555, guid: 30bf4819dee88a0419769314b01e528d,
+        type: 3}
+      propertyPath: m_Layer
+      value: 10
+      objectReference: {fileID: 0}
+    - target: {fileID: 4473690118738214368, guid: 30bf4819dee88a0419769314b01e528d,
+        type: 3}
+      propertyPath: m_Layer
+      value: 10
+      objectReference: {fileID: 0}
+    - target: {fileID: 4482305243896537383, guid: 30bf4819dee88a0419769314b01e528d,
+        type: 3}
+      propertyPath: m_Layer
+      value: 10
+      objectReference: {fileID: 0}
+    - target: {fileID: 4637730278470969272, guid: 30bf4819dee88a0419769314b01e528d,
+        type: 3}
+      propertyPath: m_Layer
+      value: 10
+      objectReference: {fileID: 0}
+    - target: {fileID: 4652842256768873223, guid: 30bf4819dee88a0419769314b01e528d,
+        type: 3}
+      propertyPath: m_Layer
+      value: 10
+      objectReference: {fileID: 0}
+    - target: {fileID: 4863888020147661853, guid: 30bf4819dee88a0419769314b01e528d,
+        type: 3}
+      propertyPath: m_Layer
+      value: 10
+      objectReference: {fileID: 0}
+    - target: {fileID: 4872557281682845950, guid: 30bf4819dee88a0419769314b01e528d,
+        type: 3}
+      propertyPath: m_Layer
+      value: 10
+      objectReference: {fileID: 0}
+    - target: {fileID: 4987371239978511321, guid: 30bf4819dee88a0419769314b01e528d,
+        type: 3}
+      propertyPath: m_Layer
+      value: 10
+      objectReference: {fileID: 0}
+    - target: {fileID: 5026875490612291392, guid: 30bf4819dee88a0419769314b01e528d,
+        type: 3}
+      propertyPath: m_Layer
+      value: 10
+      objectReference: {fileID: 0}
+    - target: {fileID: 5164462239695192184, guid: 30bf4819dee88a0419769314b01e528d,
+        type: 3}
+      propertyPath: m_Layer
+      value: 10
+      objectReference: {fileID: 0}
+    - target: {fileID: 5406534649382483760, guid: 30bf4819dee88a0419769314b01e528d,
+        type: 3}
+      propertyPath: m_Layer
+      value: 10
+      objectReference: {fileID: 0}
+    - target: {fileID: 5444909250914898021, guid: 30bf4819dee88a0419769314b01e528d,
+        type: 3}
+      propertyPath: m_Layer
+      value: 10
+      objectReference: {fileID: 0}
+    - target: {fileID: 5613229001795397398, guid: 30bf4819dee88a0419769314b01e528d,
+        type: 3}
+      propertyPath: m_Layer
+      value: 10
+      objectReference: {fileID: 0}
+    - target: {fileID: 5719276500109478591, guid: 30bf4819dee88a0419769314b01e528d,
+        type: 3}
+      propertyPath: m_Layer
+      value: 10
+      objectReference: {fileID: 0}
+    - target: {fileID: 5780122605503124989, guid: 30bf4819dee88a0419769314b01e528d,
+        type: 3}
+      propertyPath: m_Layer
+      value: 10
       objectReference: {fileID: 0}
     - target: {fileID: 5992588773650827194, guid: 30bf4819dee88a0419769314b01e528d,
         type: 3}
@@ -343,6 +623,21 @@ PrefabInstance:
       propertyPath: m_LocalEulerAnglesHint.z
       value: 0
       objectReference: {fileID: 0}
+    - target: {fileID: 6095779094040874128, guid: 30bf4819dee88a0419769314b01e528d,
+        type: 3}
+      propertyPath: m_Layer
+      value: 10
+      objectReference: {fileID: 0}
+    - target: {fileID: 6110467079140254080, guid: 30bf4819dee88a0419769314b01e528d,
+        type: 3}
+      propertyPath: m_Layer
+      value: 10
+      objectReference: {fileID: 0}
+    - target: {fileID: 6121801154587576196, guid: 30bf4819dee88a0419769314b01e528d,
+        type: 3}
+      propertyPath: m_Layer
+      value: 10
+      objectReference: {fileID: 0}
     - target: {fileID: 6237948811456239767, guid: 30bf4819dee88a0419769314b01e528d,
         type: 3}
       propertyPath: m_LocalPosition.y
@@ -353,20 +648,180 @@ PrefabInstance:
       propertyPath: m_LocalPosition.z
       value: -0.098
       objectReference: {fileID: 0}
+    - target: {fileID: 6365923299138312313, guid: 30bf4819dee88a0419769314b01e528d,
+        type: 3}
+      propertyPath: m_Layer
+      value: 10
+      objectReference: {fileID: 0}
+    - target: {fileID: 6584491239549475412, guid: 30bf4819dee88a0419769314b01e528d,
+        type: 3}
+      propertyPath: m_Layer
+      value: 10
+      objectReference: {fileID: 0}
     - target: {fileID: 6598454482460153216, guid: 30bf4819dee88a0419769314b01e528d,
         type: 3}
       propertyPath: m_IsActive
       value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6624423634306512642, guid: 30bf4819dee88a0419769314b01e528d,
+        type: 3}
+      propertyPath: m_Layer
+      value: 10
+      objectReference: {fileID: 0}
+    - target: {fileID: 6681171833928361111, guid: 30bf4819dee88a0419769314b01e528d,
+        type: 3}
+      propertyPath: m_Layer
+      value: 10
+      objectReference: {fileID: 0}
+    - target: {fileID: 6718587865807851248, guid: 30bf4819dee88a0419769314b01e528d,
+        type: 3}
+      propertyPath: m_Layer
+      value: 10
+      objectReference: {fileID: 0}
+    - target: {fileID: 6773569009845242904, guid: 30bf4819dee88a0419769314b01e528d,
+        type: 3}
+      propertyPath: m_Layer
+      value: 10
+      objectReference: {fileID: 0}
+    - target: {fileID: 6809720634460705589, guid: 30bf4819dee88a0419769314b01e528d,
+        type: 3}
+      propertyPath: m_Layer
+      value: 10
       objectReference: {fileID: 0}
     - target: {fileID: 6877081354341892973, guid: 30bf4819dee88a0419769314b01e528d,
         type: 3}
       propertyPath: m_Name
       value: SovietPreview
       objectReference: {fileID: 0}
+    - target: {fileID: 6877081354341892973, guid: 30bf4819dee88a0419769314b01e528d,
+        type: 3}
+      propertyPath: m_Layer
+      value: 10
+      objectReference: {fileID: 0}
+    - target: {fileID: 6882920341369113117, guid: 30bf4819dee88a0419769314b01e528d,
+        type: 3}
+      propertyPath: m_Layer
+      value: 10
+      objectReference: {fileID: 0}
+    - target: {fileID: 7001577947775744023, guid: 30bf4819dee88a0419769314b01e528d,
+        type: 3}
+      propertyPath: m_Layer
+      value: 10
+      objectReference: {fileID: 0}
+    - target: {fileID: 7249100583204381611, guid: 30bf4819dee88a0419769314b01e528d,
+        type: 3}
+      propertyPath: m_Layer
+      value: 10
+      objectReference: {fileID: 0}
+    - target: {fileID: 7325023011466767943, guid: 30bf4819dee88a0419769314b01e528d,
+        type: 3}
+      propertyPath: m_Layer
+      value: 10
+      objectReference: {fileID: 0}
+    - target: {fileID: 7406508809675439783, guid: 30bf4819dee88a0419769314b01e528d,
+        type: 3}
+      propertyPath: m_Layer
+      value: 10
+      objectReference: {fileID: 0}
+    - target: {fileID: 7424314279250497104, guid: 30bf4819dee88a0419769314b01e528d,
+        type: 3}
+      propertyPath: m_Layer
+      value: 10
+      objectReference: {fileID: 0}
+    - target: {fileID: 7522375446475005406, guid: 30bf4819dee88a0419769314b01e528d,
+        type: 3}
+      propertyPath: m_Layer
+      value: 10
+      objectReference: {fileID: 0}
+    - target: {fileID: 7554718679652457683, guid: 30bf4819dee88a0419769314b01e528d,
+        type: 3}
+      propertyPath: m_Layer
+      value: 10
+      objectReference: {fileID: 0}
+    - target: {fileID: 7688283879789459056, guid: 30bf4819dee88a0419769314b01e528d,
+        type: 3}
+      propertyPath: m_Layer
+      value: 10
+      objectReference: {fileID: 0}
+    - target: {fileID: 7808112300584563375, guid: 30bf4819dee88a0419769314b01e528d,
+        type: 3}
+      propertyPath: m_Layer
+      value: 10
+      objectReference: {fileID: 0}
     - target: {fileID: 8005175832501941855, guid: 30bf4819dee88a0419769314b01e528d,
         type: 3}
       propertyPath: m_IsActive
       value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8106499866229324954, guid: 30bf4819dee88a0419769314b01e528d,
+        type: 3}
+      propertyPath: m_Layer
+      value: 10
+      objectReference: {fileID: 0}
+    - target: {fileID: 8130189534081471645, guid: 30bf4819dee88a0419769314b01e528d,
+        type: 3}
+      propertyPath: m_Layer
+      value: 10
+      objectReference: {fileID: 0}
+    - target: {fileID: 8179408258633018461, guid: 30bf4819dee88a0419769314b01e528d,
+        type: 3}
+      propertyPath: m_Layer
+      value: 10
+      objectReference: {fileID: 0}
+    - target: {fileID: 8218242522365453559, guid: 30bf4819dee88a0419769314b01e528d,
+        type: 3}
+      propertyPath: m_Layer
+      value: 10
+      objectReference: {fileID: 0}
+    - target: {fileID: 8311519655428684886, guid: 30bf4819dee88a0419769314b01e528d,
+        type: 3}
+      propertyPath: m_Layer
+      value: 10
+      objectReference: {fileID: 0}
+    - target: {fileID: 8361781875805187690, guid: 30bf4819dee88a0419769314b01e528d,
+        type: 3}
+      propertyPath: m_Layer
+      value: 10
+      objectReference: {fileID: 0}
+    - target: {fileID: 8384367274393602065, guid: 30bf4819dee88a0419769314b01e528d,
+        type: 3}
+      propertyPath: m_Layer
+      value: 10
+      objectReference: {fileID: 0}
+    - target: {fileID: 8476101779780616163, guid: 30bf4819dee88a0419769314b01e528d,
+        type: 3}
+      propertyPath: m_Layer
+      value: 10
+      objectReference: {fileID: 0}
+    - target: {fileID: 8597763223892456073, guid: 30bf4819dee88a0419769314b01e528d,
+        type: 3}
+      propertyPath: m_Layer
+      value: 10
+      objectReference: {fileID: 0}
+    - target: {fileID: 8695360556326365357, guid: 30bf4819dee88a0419769314b01e528d,
+        type: 3}
+      propertyPath: m_Layer
+      value: 10
+      objectReference: {fileID: 0}
+    - target: {fileID: 8701261906350330839, guid: 30bf4819dee88a0419769314b01e528d,
+        type: 3}
+      propertyPath: m_Layer
+      value: 10
+      objectReference: {fileID: 0}
+    - target: {fileID: 8846637692444832324, guid: 30bf4819dee88a0419769314b01e528d,
+        type: 3}
+      propertyPath: m_Layer
+      value: 10
+      objectReference: {fileID: 0}
+    - target: {fileID: 9143872161870939519, guid: 30bf4819dee88a0419769314b01e528d,
+        type: 3}
+      propertyPath: m_Layer
+      value: 10
+      objectReference: {fileID: 0}
+    - target: {fileID: 9177322169602024258, guid: 30bf4819dee88a0419769314b01e528d,
+        type: 3}
+      propertyPath: m_Layer
+      value: 10
       objectReference: {fileID: 0}
     m_RemovedComponents: []
     m_RemovedGameObjects: []

--- a/Assets/Characters/Players/SilverSprinter.prefab
+++ b/Assets/Characters/Players/SilverSprinter.prefab
@@ -9,7 +9,7 @@ GameObject:
   serializedVersion: 6
   m_Component:
   - component: {fileID: 5729454866748943982}
-  m_Layer: 0
+  m_Layer: 10
   m_Name: ItemDropPoint
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -39,10 +39,89 @@ PrefabInstance:
     serializedVersion: 3
     m_TransformParent: {fileID: 6971382318219086686}
     m_Modifications:
+    - target: {fileID: 1157718230329557, guid: 8a58a162f32a63e45b0379fa05ae4c3d, type: 3}
+      propertyPath: m_Layer
+      value: 10
+      objectReference: {fileID: 0}
+    - target: {fileID: 104445048535371281, guid: 8a58a162f32a63e45b0379fa05ae4c3d,
+        type: 3}
+      propertyPath: m_Layer
+      value: 10
+      objectReference: {fileID: 0}
+    - target: {fileID: 311319840923922181, guid: 8a58a162f32a63e45b0379fa05ae4c3d,
+        type: 3}
+      propertyPath: m_Layer
+      value: 10
+      objectReference: {fileID: 0}
+    - target: {fileID: 582924430135936658, guid: 8a58a162f32a63e45b0379fa05ae4c3d,
+        type: 3}
+      propertyPath: m_Layer
+      value: 10
+      objectReference: {fileID: 0}
+    - target: {fileID: 659173811324993088, guid: 8a58a162f32a63e45b0379fa05ae4c3d,
+        type: 3}
+      propertyPath: m_Layer
+      value: 10
+      objectReference: {fileID: 0}
+    - target: {fileID: 825803022100710459, guid: 8a58a162f32a63e45b0379fa05ae4c3d,
+        type: 3}
+      propertyPath: m_Layer
+      value: 10
+      objectReference: {fileID: 0}
+    - target: {fileID: 868137676901998158, guid: 8a58a162f32a63e45b0379fa05ae4c3d,
+        type: 3}
+      propertyPath: m_Layer
+      value: 10
+      objectReference: {fileID: 0}
+    - target: {fileID: 912527374832103004, guid: 8a58a162f32a63e45b0379fa05ae4c3d,
+        type: 3}
+      propertyPath: m_Layer
+      value: 10
+      objectReference: {fileID: 0}
+    - target: {fileID: 1089676010729251824, guid: 8a58a162f32a63e45b0379fa05ae4c3d,
+        type: 3}
+      propertyPath: m_Layer
+      value: 10
+      objectReference: {fileID: 0}
+    - target: {fileID: 1146248684644416600, guid: 8a58a162f32a63e45b0379fa05ae4c3d,
+        type: 3}
+      propertyPath: m_Layer
+      value: 10
+      objectReference: {fileID: 0}
+    - target: {fileID: 1356002633777226530, guid: 8a58a162f32a63e45b0379fa05ae4c3d,
+        type: 3}
+      propertyPath: m_Layer
+      value: 10
+      objectReference: {fileID: 0}
+    - target: {fileID: 1589743583533952569, guid: 8a58a162f32a63e45b0379fa05ae4c3d,
+        type: 3}
+      propertyPath: m_Layer
+      value: 10
+      objectReference: {fileID: 0}
     - target: {fileID: 1601384168153273060, guid: 8a58a162f32a63e45b0379fa05ae4c3d,
         type: 3}
       propertyPath: m_IsActive
       value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1851904819167078413, guid: 8a58a162f32a63e45b0379fa05ae4c3d,
+        type: 3}
+      propertyPath: m_Layer
+      value: 10
+      objectReference: {fileID: 0}
+    - target: {fileID: 1886780480133931407, guid: 8a58a162f32a63e45b0379fa05ae4c3d,
+        type: 3}
+      propertyPath: m_Layer
+      value: 10
+      objectReference: {fileID: 0}
+    - target: {fileID: 1902916007025428406, guid: 8a58a162f32a63e45b0379fa05ae4c3d,
+        type: 3}
+      propertyPath: m_Layer
+      value: 10
+      objectReference: {fileID: 0}
+    - target: {fileID: 1946016456874407221, guid: 8a58a162f32a63e45b0379fa05ae4c3d,
+        type: 3}
+      propertyPath: m_Layer
+      value: 10
       objectReference: {fileID: 0}
     - target: {fileID: 1962034974697824243, guid: 8a58a162f32a63e45b0379fa05ae4c3d,
         type: 3}
@@ -58,6 +137,16 @@ PrefabInstance:
         type: 3}
       propertyPath: m_LocalPosition.z
       value: -0.102
+      objectReference: {fileID: 0}
+    - target: {fileID: 2068358868944245838, guid: 8a58a162f32a63e45b0379fa05ae4c3d,
+        type: 3}
+      propertyPath: m_Layer
+      value: 10
+      objectReference: {fileID: 0}
+    - target: {fileID: 2097618861643390514, guid: 8a58a162f32a63e45b0379fa05ae4c3d,
+        type: 3}
+      propertyPath: m_Layer
+      value: 10
       objectReference: {fileID: 0}
     - target: {fileID: 2198560032798884062, guid: 8a58a162f32a63e45b0379fa05ae4c3d,
         type: 3}
@@ -89,10 +178,215 @@ PrefabInstance:
       propertyPath: m_LocalEulerAnglesHint.x
       value: 2
       objectReference: {fileID: 0}
+    - target: {fileID: 2238490329261721246, guid: 8a58a162f32a63e45b0379fa05ae4c3d,
+        type: 3}
+      propertyPath: m_Layer
+      value: 10
+      objectReference: {fileID: 0}
+    - target: {fileID: 2329261206180175757, guid: 8a58a162f32a63e45b0379fa05ae4c3d,
+        type: 3}
+      propertyPath: m_Layer
+      value: 10
+      objectReference: {fileID: 0}
     - target: {fileID: 2500395061166682427, guid: 8a58a162f32a63e45b0379fa05ae4c3d,
         type: 3}
       propertyPath: m_IsActive
       value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2585658545495306477, guid: 8a58a162f32a63e45b0379fa05ae4c3d,
+        type: 3}
+      propertyPath: m_Layer
+      value: 10
+      objectReference: {fileID: 0}
+    - target: {fileID: 2638097202410505977, guid: 8a58a162f32a63e45b0379fa05ae4c3d,
+        type: 3}
+      propertyPath: m_Layer
+      value: 10
+      objectReference: {fileID: 0}
+    - target: {fileID: 2793389295561618958, guid: 8a58a162f32a63e45b0379fa05ae4c3d,
+        type: 3}
+      propertyPath: m_Layer
+      value: 10
+      objectReference: {fileID: 0}
+    - target: {fileID: 2952348702470409267, guid: 8a58a162f32a63e45b0379fa05ae4c3d,
+        type: 3}
+      propertyPath: m_Layer
+      value: 10
+      objectReference: {fileID: 0}
+    - target: {fileID: 2996690223711638892, guid: 8a58a162f32a63e45b0379fa05ae4c3d,
+        type: 3}
+      propertyPath: m_Layer
+      value: 10
+      objectReference: {fileID: 0}
+    - target: {fileID: 3026850195177461591, guid: 8a58a162f32a63e45b0379fa05ae4c3d,
+        type: 3}
+      propertyPath: m_Layer
+      value: 10
+      objectReference: {fileID: 0}
+    - target: {fileID: 3172382220397459751, guid: 8a58a162f32a63e45b0379fa05ae4c3d,
+        type: 3}
+      propertyPath: m_Layer
+      value: 10
+      objectReference: {fileID: 0}
+    - target: {fileID: 3591845765715544544, guid: 8a58a162f32a63e45b0379fa05ae4c3d,
+        type: 3}
+      propertyPath: m_Layer
+      value: 10
+      objectReference: {fileID: 0}
+    - target: {fileID: 3632579350515031866, guid: 8a58a162f32a63e45b0379fa05ae4c3d,
+        type: 3}
+      propertyPath: m_Layer
+      value: 10
+      objectReference: {fileID: 0}
+    - target: {fileID: 3758223403114564934, guid: 8a58a162f32a63e45b0379fa05ae4c3d,
+        type: 3}
+      propertyPath: m_Layer
+      value: 10
+      objectReference: {fileID: 0}
+    - target: {fileID: 3828562883458874834, guid: 8a58a162f32a63e45b0379fa05ae4c3d,
+        type: 3}
+      propertyPath: m_Layer
+      value: 10
+      objectReference: {fileID: 0}
+    - target: {fileID: 4186231825138697073, guid: 8a58a162f32a63e45b0379fa05ae4c3d,
+        type: 3}
+      propertyPath: m_Layer
+      value: 10
+      objectReference: {fileID: 0}
+    - target: {fileID: 4262413805298931751, guid: 8a58a162f32a63e45b0379fa05ae4c3d,
+        type: 3}
+      propertyPath: m_Layer
+      value: 10
+      objectReference: {fileID: 0}
+    - target: {fileID: 4405746339881462269, guid: 8a58a162f32a63e45b0379fa05ae4c3d,
+        type: 3}
+      propertyPath: m_Layer
+      value: 10
+      objectReference: {fileID: 0}
+    - target: {fileID: 4673518371860064700, guid: 8a58a162f32a63e45b0379fa05ae4c3d,
+        type: 3}
+      propertyPath: m_Layer
+      value: 10
+      objectReference: {fileID: 0}
+    - target: {fileID: 4822480185849218736, guid: 8a58a162f32a63e45b0379fa05ae4c3d,
+        type: 3}
+      propertyPath: m_Layer
+      value: 10
+      objectReference: {fileID: 0}
+    - target: {fileID: 4853009037455261032, guid: 8a58a162f32a63e45b0379fa05ae4c3d,
+        type: 3}
+      propertyPath: m_Layer
+      value: 10
+      objectReference: {fileID: 0}
+    - target: {fileID: 4945172561979973711, guid: 8a58a162f32a63e45b0379fa05ae4c3d,
+        type: 3}
+      propertyPath: m_Layer
+      value: 10
+      objectReference: {fileID: 0}
+    - target: {fileID: 5126978832201044412, guid: 8a58a162f32a63e45b0379fa05ae4c3d,
+        type: 3}
+      propertyPath: m_Layer
+      value: 10
+      objectReference: {fileID: 0}
+    - target: {fileID: 5329450315922558519, guid: 8a58a162f32a63e45b0379fa05ae4c3d,
+        type: 3}
+      propertyPath: m_Layer
+      value: 10
+      objectReference: {fileID: 0}
+    - target: {fileID: 5526359655983744245, guid: 8a58a162f32a63e45b0379fa05ae4c3d,
+        type: 3}
+      propertyPath: m_Layer
+      value: 10
+      objectReference: {fileID: 0}
+    - target: {fileID: 5532182391507984796, guid: 8a58a162f32a63e45b0379fa05ae4c3d,
+        type: 3}
+      propertyPath: m_Layer
+      value: 10
+      objectReference: {fileID: 0}
+    - target: {fileID: 5551079671797685827, guid: 8a58a162f32a63e45b0379fa05ae4c3d,
+        type: 3}
+      propertyPath: m_Layer
+      value: 10
+      objectReference: {fileID: 0}
+    - target: {fileID: 5557103654635940273, guid: 8a58a162f32a63e45b0379fa05ae4c3d,
+        type: 3}
+      propertyPath: m_Layer
+      value: 10
+      objectReference: {fileID: 0}
+    - target: {fileID: 5636551062543868264, guid: 8a58a162f32a63e45b0379fa05ae4c3d,
+        type: 3}
+      propertyPath: m_Layer
+      value: 10
+      objectReference: {fileID: 0}
+    - target: {fileID: 5726964391465705077, guid: 8a58a162f32a63e45b0379fa05ae4c3d,
+        type: 3}
+      propertyPath: m_Layer
+      value: 10
+      objectReference: {fileID: 0}
+    - target: {fileID: 5793263499714744493, guid: 8a58a162f32a63e45b0379fa05ae4c3d,
+        type: 3}
+      propertyPath: m_Layer
+      value: 10
+      objectReference: {fileID: 0}
+    - target: {fileID: 5810839773363117769, guid: 8a58a162f32a63e45b0379fa05ae4c3d,
+        type: 3}
+      propertyPath: m_Layer
+      value: 10
+      objectReference: {fileID: 0}
+    - target: {fileID: 5876679307241684730, guid: 8a58a162f32a63e45b0379fa05ae4c3d,
+        type: 3}
+      propertyPath: m_Layer
+      value: 10
+      objectReference: {fileID: 0}
+    - target: {fileID: 5954254116369502338, guid: 8a58a162f32a63e45b0379fa05ae4c3d,
+        type: 3}
+      propertyPath: m_Layer
+      value: 10
+      objectReference: {fileID: 0}
+    - target: {fileID: 6154897330732112312, guid: 8a58a162f32a63e45b0379fa05ae4c3d,
+        type: 3}
+      propertyPath: m_Layer
+      value: 10
+      objectReference: {fileID: 0}
+    - target: {fileID: 6166028463787658022, guid: 8a58a162f32a63e45b0379fa05ae4c3d,
+        type: 3}
+      propertyPath: m_Layer
+      value: 10
+      objectReference: {fileID: 0}
+    - target: {fileID: 6236749659293981097, guid: 8a58a162f32a63e45b0379fa05ae4c3d,
+        type: 3}
+      propertyPath: m_Layer
+      value: 10
+      objectReference: {fileID: 0}
+    - target: {fileID: 6368921429372761196, guid: 8a58a162f32a63e45b0379fa05ae4c3d,
+        type: 3}
+      propertyPath: m_Layer
+      value: 10
+      objectReference: {fileID: 0}
+    - target: {fileID: 6422700802035131005, guid: 8a58a162f32a63e45b0379fa05ae4c3d,
+        type: 3}
+      propertyPath: m_Layer
+      value: 10
+      objectReference: {fileID: 0}
+    - target: {fileID: 6550442693116729628, guid: 8a58a162f32a63e45b0379fa05ae4c3d,
+        type: 3}
+      propertyPath: m_Layer
+      value: 10
+      objectReference: {fileID: 0}
+    - target: {fileID: 6741492573505055000, guid: 8a58a162f32a63e45b0379fa05ae4c3d,
+        type: 3}
+      propertyPath: m_Layer
+      value: 10
+      objectReference: {fileID: 0}
+    - target: {fileID: 6763543146620928507, guid: 8a58a162f32a63e45b0379fa05ae4c3d,
+        type: 3}
+      propertyPath: m_Layer
+      value: 10
+      objectReference: {fileID: 0}
+    - target: {fileID: 6797264859473462912, guid: 8a58a162f32a63e45b0379fa05ae4c3d,
+        type: 3}
+      propertyPath: m_Layer
+      value: 10
       objectReference: {fileID: 0}
     - target: {fileID: 6958514736961693028, guid: 8a58a162f32a63e45b0379fa05ae4c3d,
         type: 3}
@@ -149,10 +443,40 @@ PrefabInstance:
       propertyPath: m_LocalEulerAnglesHint.z
       value: 0
       objectReference: {fileID: 0}
+    - target: {fileID: 7132708743457440657, guid: 8a58a162f32a63e45b0379fa05ae4c3d,
+        type: 3}
+      propertyPath: m_Layer
+      value: 10
+      objectReference: {fileID: 0}
+    - target: {fileID: 7303826047408564727, guid: 8a58a162f32a63e45b0379fa05ae4c3d,
+        type: 3}
+      propertyPath: m_Layer
+      value: 10
+      objectReference: {fileID: 0}
+    - target: {fileID: 7450027445489034568, guid: 8a58a162f32a63e45b0379fa05ae4c3d,
+        type: 3}
+      propertyPath: m_Layer
+      value: 10
+      objectReference: {fileID: 0}
+    - target: {fileID: 7513769929066018235, guid: 8a58a162f32a63e45b0379fa05ae4c3d,
+        type: 3}
+      propertyPath: m_Layer
+      value: 10
+      objectReference: {fileID: 0}
+    - target: {fileID: 7578761670305579716, guid: 8a58a162f32a63e45b0379fa05ae4c3d,
+        type: 3}
+      propertyPath: m_Layer
+      value: 10
+      objectReference: {fileID: 0}
     - target: {fileID: 7746803501532714720, guid: 8a58a162f32a63e45b0379fa05ae4c3d,
         type: 3}
       propertyPath: m_Name
       value: SilverSprinterPreview
+      objectReference: {fileID: 0}
+    - target: {fileID: 7746803501532714720, guid: 8a58a162f32a63e45b0379fa05ae4c3d,
+        type: 3}
+      propertyPath: m_Layer
+      value: 10
       objectReference: {fileID: 0}
     - target: {fileID: 7771608655800860638, guid: 8a58a162f32a63e45b0379fa05ae4c3d,
         type: 3}
@@ -168,6 +492,46 @@ PrefabInstance:
         type: 3}
       propertyPath: m_LocalPosition.z
       value: 0.004
+      objectReference: {fileID: 0}
+    - target: {fileID: 8039679972498624473, guid: 8a58a162f32a63e45b0379fa05ae4c3d,
+        type: 3}
+      propertyPath: m_Layer
+      value: 10
+      objectReference: {fileID: 0}
+    - target: {fileID: 8107387008086235962, guid: 8a58a162f32a63e45b0379fa05ae4c3d,
+        type: 3}
+      propertyPath: m_Layer
+      value: 10
+      objectReference: {fileID: 0}
+    - target: {fileID: 8284981204541884170, guid: 8a58a162f32a63e45b0379fa05ae4c3d,
+        type: 3}
+      propertyPath: m_Layer
+      value: 10
+      objectReference: {fileID: 0}
+    - target: {fileID: 8491031509386550364, guid: 8a58a162f32a63e45b0379fa05ae4c3d,
+        type: 3}
+      propertyPath: m_Layer
+      value: 10
+      objectReference: {fileID: 0}
+    - target: {fileID: 8622060006228723333, guid: 8a58a162f32a63e45b0379fa05ae4c3d,
+        type: 3}
+      propertyPath: m_Layer
+      value: 10
+      objectReference: {fileID: 0}
+    - target: {fileID: 8820618132137770472, guid: 8a58a162f32a63e45b0379fa05ae4c3d,
+        type: 3}
+      propertyPath: m_Layer
+      value: 10
+      objectReference: {fileID: 0}
+    - target: {fileID: 8842110262319092357, guid: 8a58a162f32a63e45b0379fa05ae4c3d,
+        type: 3}
+      propertyPath: m_Layer
+      value: 10
+      objectReference: {fileID: 0}
+    - target: {fileID: 9122632985206221278, guid: 8a58a162f32a63e45b0379fa05ae4c3d,
+        type: 3}
+      propertyPath: m_Layer
+      value: 10
       objectReference: {fileID: 0}
     m_RemovedComponents: []
     m_RemovedGameObjects: []

--- a/Assets/Characters/Players/Vorsteg.prefab
+++ b/Assets/Characters/Players/Vorsteg.prefab
@@ -9,7 +9,7 @@ GameObject:
   serializedVersion: 6
   m_Component:
   - component: {fileID: 7115039467352433421}
-  m_Layer: 0
+  m_Layer: 10
   m_Name: ItemDropPoint
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -39,15 +39,285 @@ PrefabInstance:
     serializedVersion: 3
     m_TransformParent: {fileID: 9085217468663798317}
     m_Modifications:
+    - target: {fileID: 32116966415124154, guid: a857bf3443ddd56448a06017a9a23dcf,
+        type: 3}
+      propertyPath: m_Layer
+      value: 10
+      objectReference: {fileID: 0}
+    - target: {fileID: 151841818335572191, guid: a857bf3443ddd56448a06017a9a23dcf,
+        type: 3}
+      propertyPath: m_Layer
+      value: 10
+      objectReference: {fileID: 0}
+    - target: {fileID: 305648838810459579, guid: a857bf3443ddd56448a06017a9a23dcf,
+        type: 3}
+      propertyPath: m_Layer
+      value: 10
+      objectReference: {fileID: 0}
+    - target: {fileID: 575496280686450909, guid: a857bf3443ddd56448a06017a9a23dcf,
+        type: 3}
+      propertyPath: m_Layer
+      value: 10
+      objectReference: {fileID: 0}
+    - target: {fileID: 657068000421705629, guid: a857bf3443ddd56448a06017a9a23dcf,
+        type: 3}
+      propertyPath: m_Layer
+      value: 10
+      objectReference: {fileID: 0}
+    - target: {fileID: 874434421334657688, guid: a857bf3443ddd56448a06017a9a23dcf,
+        type: 3}
+      propertyPath: m_Layer
+      value: 10
+      objectReference: {fileID: 0}
+    - target: {fileID: 1059510202414154329, guid: a857bf3443ddd56448a06017a9a23dcf,
+        type: 3}
+      propertyPath: m_Layer
+      value: 10
+      objectReference: {fileID: 0}
+    - target: {fileID: 1482680935630927356, guid: a857bf3443ddd56448a06017a9a23dcf,
+        type: 3}
+      propertyPath: m_Layer
+      value: 10
+      objectReference: {fileID: 0}
+    - target: {fileID: 1520085141537389982, guid: a857bf3443ddd56448a06017a9a23dcf,
+        type: 3}
+      propertyPath: m_Layer
+      value: 10
+      objectReference: {fileID: 0}
+    - target: {fileID: 1651269412025729065, guid: a857bf3443ddd56448a06017a9a23dcf,
+        type: 3}
+      propertyPath: m_Layer
+      value: 10
+      objectReference: {fileID: 0}
+    - target: {fileID: 1818719704257960138, guid: a857bf3443ddd56448a06017a9a23dcf,
+        type: 3}
+      propertyPath: m_Layer
+      value: 10
+      objectReference: {fileID: 0}
     - target: {fileID: 1838499791685866363, guid: a857bf3443ddd56448a06017a9a23dcf,
         type: 3}
       propertyPath: m_IsActive
       value: 0
       objectReference: {fileID: 0}
+    - target: {fileID: 1980382423544508641, guid: a857bf3443ddd56448a06017a9a23dcf,
+        type: 3}
+      propertyPath: m_Layer
+      value: 10
+      objectReference: {fileID: 0}
+    - target: {fileID: 2076418388508183341, guid: a857bf3443ddd56448a06017a9a23dcf,
+        type: 3}
+      propertyPath: m_Layer
+      value: 10
+      objectReference: {fileID: 0}
+    - target: {fileID: 2157877489364937210, guid: a857bf3443ddd56448a06017a9a23dcf,
+        type: 3}
+      propertyPath: m_Layer
+      value: 10
+      objectReference: {fileID: 0}
+    - target: {fileID: 2295273682313151095, guid: a857bf3443ddd56448a06017a9a23dcf,
+        type: 3}
+      propertyPath: m_Layer
+      value: 10
+      objectReference: {fileID: 0}
+    - target: {fileID: 2320036530072138979, guid: a857bf3443ddd56448a06017a9a23dcf,
+        type: 3}
+      propertyPath: m_Layer
+      value: 10
+      objectReference: {fileID: 0}
+    - target: {fileID: 2338255616617139757, guid: a857bf3443ddd56448a06017a9a23dcf,
+        type: 3}
+      propertyPath: m_Layer
+      value: 10
+      objectReference: {fileID: 0}
+    - target: {fileID: 2431648082193840949, guid: a857bf3443ddd56448a06017a9a23dcf,
+        type: 3}
+      propertyPath: m_Layer
+      value: 10
+      objectReference: {fileID: 0}
+    - target: {fileID: 2506102011891727999, guid: a857bf3443ddd56448a06017a9a23dcf,
+        type: 3}
+      propertyPath: m_Layer
+      value: 10
+      objectReference: {fileID: 0}
+    - target: {fileID: 2698997308809832488, guid: a857bf3443ddd56448a06017a9a23dcf,
+        type: 3}
+      propertyPath: m_Layer
+      value: 10
+      objectReference: {fileID: 0}
+    - target: {fileID: 2728824329918816890, guid: a857bf3443ddd56448a06017a9a23dcf,
+        type: 3}
+      propertyPath: m_Layer
+      value: 10
+      objectReference: {fileID: 0}
+    - target: {fileID: 2808907525034710904, guid: a857bf3443ddd56448a06017a9a23dcf,
+        type: 3}
+      propertyPath: m_Layer
+      value: 10
+      objectReference: {fileID: 0}
+    - target: {fileID: 2998280932187038625, guid: a857bf3443ddd56448a06017a9a23dcf,
+        type: 3}
+      propertyPath: m_Layer
+      value: 10
+      objectReference: {fileID: 0}
+    - target: {fileID: 3007038747736211172, guid: a857bf3443ddd56448a06017a9a23dcf,
+        type: 3}
+      propertyPath: m_Layer
+      value: 10
+      objectReference: {fileID: 0}
     - target: {fileID: 3245366573617000612, guid: a857bf3443ddd56448a06017a9a23dcf,
         type: 3}
       propertyPath: m_IsActive
       value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3421653458663811071, guid: a857bf3443ddd56448a06017a9a23dcf,
+        type: 3}
+      propertyPath: m_Layer
+      value: 10
+      objectReference: {fileID: 0}
+    - target: {fileID: 3565776035565567251, guid: a857bf3443ddd56448a06017a9a23dcf,
+        type: 3}
+      propertyPath: m_Layer
+      value: 10
+      objectReference: {fileID: 0}
+    - target: {fileID: 3587108186324907724, guid: a857bf3443ddd56448a06017a9a23dcf,
+        type: 3}
+      propertyPath: m_Layer
+      value: 10
+      objectReference: {fileID: 0}
+    - target: {fileID: 3852484309650176025, guid: a857bf3443ddd56448a06017a9a23dcf,
+        type: 3}
+      propertyPath: m_Layer
+      value: 10
+      objectReference: {fileID: 0}
+    - target: {fileID: 3903902505718877297, guid: a857bf3443ddd56448a06017a9a23dcf,
+        type: 3}
+      propertyPath: m_Layer
+      value: 10
+      objectReference: {fileID: 0}
+    - target: {fileID: 3934414975862365115, guid: a857bf3443ddd56448a06017a9a23dcf,
+        type: 3}
+      propertyPath: m_Layer
+      value: 10
+      objectReference: {fileID: 0}
+    - target: {fileID: 4014121376481289811, guid: a857bf3443ddd56448a06017a9a23dcf,
+        type: 3}
+      propertyPath: m_Layer
+      value: 10
+      objectReference: {fileID: 0}
+    - target: {fileID: 4058207842803226324, guid: a857bf3443ddd56448a06017a9a23dcf,
+        type: 3}
+      propertyPath: m_Layer
+      value: 10
+      objectReference: {fileID: 0}
+    - target: {fileID: 4096542035618745808, guid: a857bf3443ddd56448a06017a9a23dcf,
+        type: 3}
+      propertyPath: m_Layer
+      value: 10
+      objectReference: {fileID: 0}
+    - target: {fileID: 4129194471381336114, guid: a857bf3443ddd56448a06017a9a23dcf,
+        type: 3}
+      propertyPath: m_Layer
+      value: 10
+      objectReference: {fileID: 0}
+    - target: {fileID: 4132604938080904403, guid: a857bf3443ddd56448a06017a9a23dcf,
+        type: 3}
+      propertyPath: m_Layer
+      value: 10
+      objectReference: {fileID: 0}
+    - target: {fileID: 4166764584731299810, guid: a857bf3443ddd56448a06017a9a23dcf,
+        type: 3}
+      propertyPath: m_Layer
+      value: 10
+      objectReference: {fileID: 0}
+    - target: {fileID: 4237796744009082895, guid: a857bf3443ddd56448a06017a9a23dcf,
+        type: 3}
+      propertyPath: m_Layer
+      value: 10
+      objectReference: {fileID: 0}
+    - target: {fileID: 4265177342893517819, guid: a857bf3443ddd56448a06017a9a23dcf,
+        type: 3}
+      propertyPath: m_Layer
+      value: 10
+      objectReference: {fileID: 0}
+    - target: {fileID: 4340481620929910060, guid: a857bf3443ddd56448a06017a9a23dcf,
+        type: 3}
+      propertyPath: m_Layer
+      value: 10
+      objectReference: {fileID: 0}
+    - target: {fileID: 4446740472070407314, guid: a857bf3443ddd56448a06017a9a23dcf,
+        type: 3}
+      propertyPath: m_Layer
+      value: 10
+      objectReference: {fileID: 0}
+    - target: {fileID: 4525072578710305732, guid: a857bf3443ddd56448a06017a9a23dcf,
+        type: 3}
+      propertyPath: m_Layer
+      value: 10
+      objectReference: {fileID: 0}
+    - target: {fileID: 4539930285297227316, guid: a857bf3443ddd56448a06017a9a23dcf,
+        type: 3}
+      propertyPath: m_Layer
+      value: 10
+      objectReference: {fileID: 0}
+    - target: {fileID: 4552181996869166955, guid: a857bf3443ddd56448a06017a9a23dcf,
+        type: 3}
+      propertyPath: m_Layer
+      value: 10
+      objectReference: {fileID: 0}
+    - target: {fileID: 4676333876899055075, guid: a857bf3443ddd56448a06017a9a23dcf,
+        type: 3}
+      propertyPath: m_Layer
+      value: 10
+      objectReference: {fileID: 0}
+    - target: {fileID: 4782936361033288958, guid: a857bf3443ddd56448a06017a9a23dcf,
+        type: 3}
+      propertyPath: m_Layer
+      value: 10
+      objectReference: {fileID: 0}
+    - target: {fileID: 4893281302391282422, guid: a857bf3443ddd56448a06017a9a23dcf,
+        type: 3}
+      propertyPath: m_Layer
+      value: 10
+      objectReference: {fileID: 0}
+    - target: {fileID: 4895697950788504409, guid: a857bf3443ddd56448a06017a9a23dcf,
+        type: 3}
+      propertyPath: m_Layer
+      value: 10
+      objectReference: {fileID: 0}
+    - target: {fileID: 5044854285530548551, guid: a857bf3443ddd56448a06017a9a23dcf,
+        type: 3}
+      propertyPath: m_Layer
+      value: 10
+      objectReference: {fileID: 0}
+    - target: {fileID: 5222243134733351347, guid: a857bf3443ddd56448a06017a9a23dcf,
+        type: 3}
+      propertyPath: m_Layer
+      value: 10
+      objectReference: {fileID: 0}
+    - target: {fileID: 5488346324125834719, guid: a857bf3443ddd56448a06017a9a23dcf,
+        type: 3}
+      propertyPath: m_Layer
+      value: 10
+      objectReference: {fileID: 0}
+    - target: {fileID: 5580185818322460358, guid: a857bf3443ddd56448a06017a9a23dcf,
+        type: 3}
+      propertyPath: m_Layer
+      value: 10
+      objectReference: {fileID: 0}
+    - target: {fileID: 5950748917819452346, guid: a857bf3443ddd56448a06017a9a23dcf,
+        type: 3}
+      propertyPath: m_Layer
+      value: 10
+      objectReference: {fileID: 0}
+    - target: {fileID: 6086692595456866410, guid: a857bf3443ddd56448a06017a9a23dcf,
+        type: 3}
+      propertyPath: m_Layer
+      value: 10
+      objectReference: {fileID: 0}
+    - target: {fileID: 6286968395448212418, guid: a857bf3443ddd56448a06017a9a23dcf,
+        type: 3}
+      propertyPath: m_Layer
+      value: 10
       objectReference: {fileID: 0}
     - target: {fileID: 6384796944825150538, guid: a857bf3443ddd56448a06017a9a23dcf,
         type: 3}
@@ -99,10 +369,115 @@ PrefabInstance:
       propertyPath: m_LocalEulerAnglesHint.z
       value: 0
       objectReference: {fileID: 0}
+    - target: {fileID: 6547879531240869584, guid: a857bf3443ddd56448a06017a9a23dcf,
+        type: 3}
+      propertyPath: m_Layer
+      value: 10
+      objectReference: {fileID: 0}
+    - target: {fileID: 6660221011166416875, guid: a857bf3443ddd56448a06017a9a23dcf,
+        type: 3}
+      propertyPath: m_Layer
+      value: 10
+      objectReference: {fileID: 0}
+    - target: {fileID: 6723657548691850287, guid: a857bf3443ddd56448a06017a9a23dcf,
+        type: 3}
+      propertyPath: m_Layer
+      value: 10
+      objectReference: {fileID: 0}
+    - target: {fileID: 6768848499968608358, guid: a857bf3443ddd56448a06017a9a23dcf,
+        type: 3}
+      propertyPath: m_Layer
+      value: 10
+      objectReference: {fileID: 0}
+    - target: {fileID: 6983643074538360203, guid: a857bf3443ddd56448a06017a9a23dcf,
+        type: 3}
+      propertyPath: m_Layer
+      value: 10
+      objectReference: {fileID: 0}
+    - target: {fileID: 7255356290657367500, guid: a857bf3443ddd56448a06017a9a23dcf,
+        type: 3}
+      propertyPath: m_Layer
+      value: 10
+      objectReference: {fileID: 0}
+    - target: {fileID: 7270048133691433277, guid: a857bf3443ddd56448a06017a9a23dcf,
+        type: 3}
+      propertyPath: m_Layer
+      value: 10
+      objectReference: {fileID: 0}
+    - target: {fileID: 7556601598063254005, guid: a857bf3443ddd56448a06017a9a23dcf,
+        type: 3}
+      propertyPath: m_Layer
+      value: 10
+      objectReference: {fileID: 0}
+    - target: {fileID: 7584126988843834161, guid: a857bf3443ddd56448a06017a9a23dcf,
+        type: 3}
+      propertyPath: m_Layer
+      value: 10
+      objectReference: {fileID: 0}
+    - target: {fileID: 7605935428988245506, guid: a857bf3443ddd56448a06017a9a23dcf,
+        type: 3}
+      propertyPath: m_Layer
+      value: 10
+      objectReference: {fileID: 0}
+    - target: {fileID: 7897878634628398784, guid: a857bf3443ddd56448a06017a9a23dcf,
+        type: 3}
+      propertyPath: m_Layer
+      value: 10
+      objectReference: {fileID: 0}
     - target: {fileID: 7980382004344233561, guid: a857bf3443ddd56448a06017a9a23dcf,
         type: 3}
       propertyPath: m_Name
       value: VorstegPreview
+      objectReference: {fileID: 0}
+    - target: {fileID: 7980382004344233561, guid: a857bf3443ddd56448a06017a9a23dcf,
+        type: 3}
+      propertyPath: m_Layer
+      value: 10
+      objectReference: {fileID: 0}
+    - target: {fileID: 7996622593044163132, guid: a857bf3443ddd56448a06017a9a23dcf,
+        type: 3}
+      propertyPath: m_Layer
+      value: 10
+      objectReference: {fileID: 0}
+    - target: {fileID: 8066198108423938816, guid: a857bf3443ddd56448a06017a9a23dcf,
+        type: 3}
+      propertyPath: m_Layer
+      value: 10
+      objectReference: {fileID: 0}
+    - target: {fileID: 8174702969849000873, guid: a857bf3443ddd56448a06017a9a23dcf,
+        type: 3}
+      propertyPath: m_Layer
+      value: 10
+      objectReference: {fileID: 0}
+    - target: {fileID: 8304929360963041534, guid: a857bf3443ddd56448a06017a9a23dcf,
+        type: 3}
+      propertyPath: m_Layer
+      value: 10
+      objectReference: {fileID: 0}
+    - target: {fileID: 8326069642865438680, guid: a857bf3443ddd56448a06017a9a23dcf,
+        type: 3}
+      propertyPath: m_Layer
+      value: 10
+      objectReference: {fileID: 0}
+    - target: {fileID: 8509770411311296096, guid: a857bf3443ddd56448a06017a9a23dcf,
+        type: 3}
+      propertyPath: m_Layer
+      value: 10
+      objectReference: {fileID: 0}
+    - target: {fileID: 8817091814000910611, guid: a857bf3443ddd56448a06017a9a23dcf,
+        type: 3}
+      propertyPath: m_Layer
+      value: 10
+      objectReference: {fileID: 0}
+    - target: {fileID: 8952518497342989807, guid: a857bf3443ddd56448a06017a9a23dcf,
+        type: 3}
+      propertyPath: m_Layer
+      value: 10
+      objectReference: {fileID: 0}
+    - target: {fileID: 8980673475867660495, guid: a857bf3443ddd56448a06017a9a23dcf,
+        type: 3}
+      propertyPath: m_Layer
+      value: 10
       objectReference: {fileID: 0}
     m_RemovedComponents: []
     m_RemovedGameObjects: []


### PR DESCRIPTION
Ensured that the bodies of all players use 'Racer' layer. This. prevents the camera from clipping into the player's body due to Physics.Linecast encountering their own limbs while ragdolling.