### PR TITLE
Fix to URP thumbnail bug

### DIFF
--- a/Assets/Scripts/Greenscreen/SnapshotCamera.cs
+++ b/Assets/Scripts/Greenscreen/SnapshotCamera.cs
@@ -67,8 +67,8 @@ public class SnapshotCamera : MonoBehaviour
             }
 
             RenderTexture thumbRT = new RenderTexture(thumbWidth, thumbHeight, 24);
-            Graphics.Blit(RenderTexture.active, thumbRT);
-            RenderTexture.active = thumbRT;
+            Graphics.Blit(snapCam.targetTexture, thumbRT);
+            snapCam.targetTexture = thumbRT;
            
             RenderAndExport(thumbWidth, thumbHeight, SnapshotName(true, dt));
         }


### PR DESCRIPTION
URP treats the active render texture differently, I have fixed the snapshot camera to function as expected with URP by manually setting the snapCam's target render texture instead of relying on the active render texture